### PR TITLE
Fix Buy Now button overflow in featured category cards

### DIFF
--- a/components/BuyerPanel/products/ProductCard.jsx
+++ b/components/BuyerPanel/products/ProductCard.jsx
@@ -309,7 +309,7 @@ export default function ProductCard({ product, viewMode = "grid" }) {
 						</div>
 
                                                {/* Actions */}
-                                               <div className="flex items-center justify-between gap-2">
+                                               <div className="flex items-center justify-between gap-2 flex-wrap">
                                                        <div className="flex gap-2">
                                                                <Button
                                                                        variant="outline"
@@ -330,7 +330,7 @@ export default function ProductCard({ product, viewMode = "grid" }) {
                                                                </Button>
                                                        </div>
 
-                                                       <div className="flex items-center gap-2">
+                                                       <div className="flex items-center gap-2 flex-wrap">
                                                                <div className="flex items-center border rounded-full">
                                                                        <Button
                                                                                variant="ghost"
@@ -353,7 +353,7 @@ export default function ProductCard({ product, viewMode = "grid" }) {
                                                                <Button
                                                                        onClick={handleBuyNow}
                                                                        disabled={!product.inStock || isLoading}
-                                                                       className="bg-black text-white hover:bg-gray-800 rounded-full flex-1 max-w-[120px]"
+                                                                       className="bg-black text-white hover:bg-gray-800 rounded-full flex-shrink-0 whitespace-nowrap"
                                                                        size="sm"
                                                                >
                                                                        Buy Now


### PR DESCRIPTION
## Summary
- prevent product card action bar from overflowing by wrapping content
- ensure Buy Now button doesn't expand beyond its container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68a824e13648832e8a92ffc86b462e83