### PR TITLE
Handle duplicate categories and support subcategories

### DIFF
--- a/app/api/admin/categories/route.js
+++ b/app/api/admin/categories/route.js
@@ -78,9 +78,15 @@ export async function GET(request) {
 export async function POST(request) {
 	await dbConnect();
 
-	try {
-		const { name, description, icon, published, sortOrder } =
-			await request.json();
+        try {
+                const {
+                        name,
+                        description,
+                        icon,
+                        published,
+                        sortOrder,
+                        subCategories,
+                } = await request.json();
 
 		if (!name || !description) {
 			return Response.json(
@@ -89,13 +95,16 @@ export async function POST(request) {
 			);
 		}
 
-		const category = new Category({
-			name,
-			description,
-			icon: icon || "",
-			published: published !== undefined ? published : true,
-			sortOrder: sortOrder || 0,
-		});
+                const category = new Category({
+                        name,
+                        description,
+                        icon: icon || "",
+                        published: published !== undefined ? published : true,
+                        sortOrder: sortOrder || 0,
+                        subCategories: Array.isArray(subCategories)
+                                ? subCategories
+                                : [],
+                });
 
 		await category.save();
 
@@ -123,7 +132,7 @@ export async function PUT(request) {
 	await dbConnect();
 
 	try {
-		const { categoryId, ...updateData } = await request.json();
+                const { categoryId, subCategories, ...updateData } = await request.json();
 
 		if (!categoryId) {
 			return Response.json(
@@ -132,9 +141,19 @@ export async function PUT(request) {
 			);
 		}
 
-		const category = await Category.findByIdAndUpdate(categoryId, updateData, {
-			new: true,
-		});
+                if (subCategories !== undefined) {
+                        updateData.subCategories = Array.isArray(subCategories)
+                                ? subCategories
+                                : [];
+                }
+
+                const category = await Category.findByIdAndUpdate(
+                        categoryId,
+                        updateData,
+                        {
+                                new: true,
+                        }
+                );
 
 		if (!category) {
 			return Response.json(

--- a/components/AdminPanel/Popups/AddCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/AddCategoryPopup.jsx
@@ -21,19 +21,28 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 	const { addCategory } = useAdminCategoryStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		name: "",
-		description: "",
-		icon: "",
-		published: true,
-		sortOrder: 0,
-	});
+        const [formData, setFormData] = useState({
+                name: "",
+                description: "",
+                icon: "",
+                subCategories: "",
+                published: true,
+                sortOrder: 0,
+        });
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
 		setIsSubmitting(true);
 
-		const success = await addCategory(formData);
+                const submitData = {
+                        ...formData,
+                        subCategories: formData.subCategories
+                                .split(",")
+                                .map((s) => s.trim())
+                                .filter(Boolean),
+                };
+
+                const success = await addCategory(submitData);
 		if (success) {
 			onOpenChange(false);
 			resetForm();
@@ -46,9 +55,10 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 			name: "",
 			description: "",
 			icon: "",
-			published: true,
-			sortOrder: 0,
-		});
+                        subCategories: "",
+                        published: true,
+                        sortOrder: 0,
+                });
 	};
 
 	return (
@@ -83,8 +93,8 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 							/>
 						</div>
 
-						<div>
-							<Label htmlFor="description">Description *</Label>
+                                                <div>
+                                                        <Label htmlFor="description">Description *</Label>
 							<Textarea
 								id="description"
 								placeholder="Enter category description"
@@ -96,11 +106,30 @@ export function AddCategoryPopup({ open, onOpenChange }) {
 								rows={3}
 								required
 							/>
-						</div>
+                                                </div>
 
-						<div>
-							<Label htmlFor="icon">Icon URL</Label>
-							<Input
+                                                <div>
+                                                        <Label htmlFor="subCategories">Sub Categories</Label>
+                                                        <Input
+                                                                id="subCategories"
+                                                                placeholder="e.g. Helmets, Gloves"
+                                                                value={formData.subCategories}
+                                                                onChange={(e) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                subCategories: e.target.value,
+                                                                        })
+                                                                }
+                                                                className="mt-1"
+                                                        />
+                                                        <p className="text-xs text-gray-500 mt-1">
+                                                                Optional: comma-separated list
+                                                        </p>
+                                                </div>
+
+                                                <div>
+                                                        <Label htmlFor="icon">Icon URL</Label>
+                                                        <Input
 								id="icon"
 								placeholder="https://example.com/icon.png"
 								value={formData.icon}

--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -60,6 +60,7 @@ export function AddProductPopup({ open, onOpenChange }) {
                 description: "",
                 longDescription: "",
                 category: "",
+                subCategory: "",
                 mrp: "",
                 price: "",
                 salePrice: "",
@@ -81,6 +82,7 @@ export function AddProductPopup({ open, onOpenChange }) {
 				description: formData.description,
 				longDescription: formData.longDescription || formData.description,
                                 category: formData.category,
+                                subCategory: formData.subCategory,
                                 mrp: parseFloat(formData.mrp),
                                 price: parseFloat(formData.price),
                                 salePrice: formData.salePrice ? parseFloat(formData.salePrice) : 0,
@@ -115,6 +117,7 @@ export function AddProductPopup({ open, onOpenChange }) {
                         description: "",
                         longDescription: "",
                         category: "",
+                        subCategory: "",
                         mrp: "",
                         price: "",
                         salePrice: "",
@@ -228,6 +231,7 @@ export function AddProductPopup({ open, onOpenChange }) {
                                                                                 setFormData({
                                                                                         ...formData,
                                                                                         category: e.target.value,
+                                                                                        subCategory: "",
                                                                                 })
                                                                         }
                                                                         className="mt-1"
@@ -243,13 +247,39 @@ export function AddProductPopup({ open, onOpenChange }) {
                                                         </div>
 
                                                         <div>
+                                                                <Label htmlFor="subCategory">Sub Category</Label>
+                                                                <Input
+                                                                        id="subCategory"
+                                                                        list="admin-subcategory-list"
+                                                                        value={formData.subCategory}
+                                                                        onChange={(e) =>
+                                                                                setFormData({
+                                                                                        ...formData,
+                                                                                        subCategory: e.target.value,
+                                                                                })
+                                                                        }
+                                                                        className="mt-1"
+                                                                />
+                                                                <datalist id="admin-subcategory-list">
+                                                                        {categories
+                                                                                .find(
+                                                                                        (cat) =>
+                                                                                                cat.slug ===
+                                                                                                formData.category
+                                                                                )?.subCategories?.map((sub) => (
+                                                                                        <option key={sub} value={sub} />
+                                                                                ))}
+                                                                </datalist>
+                                                        </div>
+
+                                                        <div>
                                                                 <Label>Product Type</Label>
-								<Select
-									value={formData.type}
-									onValueChange={(value) =>
-										setFormData({ ...formData, type: value })
-									}
-								>
+                                                                <Select
+                                                                        value={formData.type}
+                                                                        onValueChange={(value) =>
+                                                                                setFormData({ ...formData, type: value })
+                                                                        }
+                                                                >
 									<SelectTrigger className="mt-1">
 										<SelectValue placeholder="Select type" />
 									</SelectTrigger>

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -141,6 +141,7 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                 setUploadResults({
                         success: results?.success || [],
                         failed: [...preValidationErrors, ...(results?.failed || [])],
+                        duplicates: results?.duplicates || [],
                 });
                 setIsSubmitting(false);
         };
@@ -259,6 +260,12 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                                                                                 products
                                                                                         </p>
                                                                                 )}
+                                                                                {uploadResults.duplicates.length > 0 && (
+                                                                                        <p>
+                                                                                                ⚠️ Duplicates assigned: {uploadResults.duplicates.length}{" "}
+                                                                                                products
+                                                                                        </p>
+                                                                                )}
                                                                         </div>
                                                                 </div>
 
@@ -279,6 +286,30 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                                                                                         <TableRow key={index}>
                                                                                                                 <TableCell>{failed.data.title || "Unknown"}</TableCell>
                                                                                                                 <TableCell>{failed.error}</TableCell>
+                                                                                                        </TableRow>
+                                                                                                ))}
+                                                                                        </TableBody>
+                                                                                </Table>
+                                                                        </div>
+                                                                )}
+
+                                                                {uploadResults.duplicates.length > 0 && (
+                                                                        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                                                                                <h4 className="font-medium text-yellow-900 mb-2">
+                                                                                        Duplicates Mapped
+                                                                                </h4>
+                                                                                <Table>
+                                                                                        <TableHeader>
+                                                                                                <TableRow>
+                                                                                                        <TableHead>Title</TableHead>
+                                                                                                        <TableHead>Existing Category</TableHead>
+                                                                                                </TableRow>
+                                                                                        </TableHeader>
+                                                                                        <TableBody>
+                                                                                                {uploadResults.duplicates.map((dup, index) => (
+                                                                                                        <TableRow key={index}>
+                                                                                                                <TableCell>{dup.title}</TableCell>
+                                                                                                                <TableCell>{dup.category}</TableCell>
                                                                                                         </TableRow>
                                                                                                 ))}
                                                                                         </TableBody>

--- a/components/AdminPanel/Popups/BulkUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkUploadPopup.jsx
@@ -58,17 +58,18 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         const results =
                                 valid.length > 0
                                         ? await bulkUploadProducts(valid)
-                                        : { success: [], failed: [] };
+                                        : { success: [], failed: [], duplicates: [] };
                         setUploadResults({
                                 success: results?.success || [],
                                 failed: [...invalid, ...(results?.failed || [])],
+                                duplicates: results?.duplicates || [],
                         });
                         if (results) {
                                 setJsonData("");
                         }
                 } catch (error) {
                         console.error("Invalid JSON format:", error);
-                        setUploadResults({ success: [], failed: [] });
+                        setUploadResults({ success: [], failed: [], duplicates: [] });
                 }
                 setIsSubmitting(false);
 	};
@@ -171,19 +172,25 @@ export function BulkUploadPopup({ open, onOpenChange }) {
 									<h4 className="font-medium text-green-900 mb-2">
 										Upload Results
 									</h4>
-									<div className="text-sm text-green-700">
-										<p>
-											✅ Successfully uploaded: {uploadResults.success.length}{" "}
-											products
-										</p>
-										{uploadResults.failed.length > 0 && (
-											<p>
-												❌ Failed to upload: {uploadResults.failed.length}{" "}
-												products
-											</p>
-										)}
-									</div>
-								</div>
+                                                                        <div className="text-sm text-green-700">
+                                                                                <p>
+                                                                                        ✅ Successfully uploaded: {uploadResults.success.length}{" "}
+                                                                                        products
+                                                                                </p>
+                                                                                {uploadResults.failed.length > 0 && (
+                                                                                        <p>
+                                                                                                ❌ Failed to upload: {uploadResults.failed.length}{" "}
+                                                                                                products
+                                                                                        </p>
+                                                                                )}
+                                                                                {uploadResults.duplicates.length > 0 && (
+                                                                                        <p>
+                                                                                                ⚠️ Duplicates assigned: {uploadResults.duplicates.length}{" "}
+                                                                                                products
+                                                                                        </p>
+                                                                                )}
+                                                                        </div>
+                                                                </div>
 
                                                                 {uploadResults.failed.length > 0 && (
                                                                         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
@@ -208,8 +215,32 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                                                                 </Table>
                                                                         </div>
                                                                 )}
-							</div>
-						)}
+
+                                                                {uploadResults.duplicates.length > 0 && (
+                                                                        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+                                                                                <h4 className="font-medium text-yellow-900 mb-2">
+                                                                                        Duplicates Mapped
+                                                                                </h4>
+                                                                                <Table>
+                                                                                        <TableHeader>
+                                                                                                <TableRow>
+                                                                                                        <TableHead>Title</TableHead>
+                                                                                                        <TableHead>Existing Category</TableHead>
+                                                                                                </TableRow>
+                                                                                        </TableHeader>
+                                                                                        <TableBody>
+                                                                                                {uploadResults.duplicates.map((dup, index) => (
+                                                                                                        <TableRow key={index}>
+                                                                                                                <TableCell>{dup.title}</TableCell>
+                                                                                                                <TableCell>{dup.category}</TableCell>
+                                                                                                        </TableRow>
+                                                                                                ))}
+                                                                                        </TableBody>
+                                                                                </Table>
+                                                                        </div>
+                                                                )}
+                                                        </div>
+                                                )}
 
 						<form onSubmit={handleSubmit} className="space-y-4">
 							<div>

--- a/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateCategoryPopup.jsx
@@ -21,25 +21,30 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 	const { updateCategory } = useAdminCategoryStore();
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const [formData, setFormData] = useState({
-		name: "",
-		description: "",
-		icon: "",
-		published: true,
-		sortOrder: 0,
-	});
+        const [formData, setFormData] = useState({
+                name: "",
+                description: "",
+                icon: "",
+                subCategories: "",
+                published: true,
+                sortOrder: 0,
+        });
 
 	useEffect(() => {
 		if (category) {
 			setFormData({
 				name: category.name || "",
 				description: category.description || "",
-				icon: category.icon || "",
-				published: category.published !== undefined ? category.published : true,
-				sortOrder: category.sortOrder || 0,
-			});
-		}
-	}, [category]);
+                                icon: category.icon || "",
+                                subCategories: category.subCategories?.join(", ") || "",
+                                published:
+                                        category.published !== undefined
+                                                ? category.published
+                                                : true,
+                                sortOrder: category.sortOrder || 0,
+                        });
+                }
+        }, [category]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -47,7 +52,15 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 
 		setIsSubmitting(true);
 
-		const success = await updateCategory(category._id, formData);
+                const submitData = {
+                        ...formData,
+                        subCategories: formData.subCategories
+                                .split(",")
+                                .map((s) => s.trim())
+                                .filter(Boolean),
+                };
+
+                const success = await updateCategory(category._id, submitData);
 		if (success) {
 			onOpenChange(false);
 		}
@@ -86,8 +99,8 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 							/>
 						</div>
 
-						<div>
-							<Label htmlFor="description">Description *</Label>
+                                                <div>
+                                                        <Label htmlFor="description">Description *</Label>
 							<Textarea
 								id="description"
 								placeholder="Enter category description"
@@ -99,11 +112,30 @@ export function UpdateCategoryPopup({ open, onOpenChange, category }) {
 								rows={3}
 								required
 							/>
-						</div>
+                                                </div>
 
-						<div>
-							<Label htmlFor="icon">Icon URL</Label>
-							<Input
+                                                <div>
+                                                        <Label htmlFor="subCategories">Sub Categories</Label>
+                                                        <Input
+                                                                id="subCategories"
+                                                                placeholder="e.g. Helmets, Gloves"
+                                                                value={formData.subCategories}
+                                                                onChange={(e) =>
+                                                                        setFormData({
+                                                                                ...formData,
+                                                                                subCategories: e.target.value,
+                                                                        })
+                                                                }
+                                                                className="mt-1"
+                                                        />
+                                                        <p className="text-xs text-gray-500 mt-1">
+                                                                Optional: comma-separated list
+                                                        </p>
+                                                </div>
+
+                                                <div>
+                                                        <Label htmlFor="icon">Icon URL</Label>
+                                                        <Input
 								id="icon"
 								placeholder="https://example.com/icon.png"
 								value={formData.icon}

--- a/components/AdminPanel/Popups/UpdateProductPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateProductPopup.jsx
@@ -301,6 +301,7 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                                                                                 setFormData({
                                                                                         ...formData,
                                                                                         category: e.target.value,
+                                                                                        subCategory: "",
                                                                                 })
                                                                         }
                                                                         className="mt-1"
@@ -319,6 +320,7 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                                                                 <Label htmlFor="subCategory">Sub Category</Label>
                                                                 <Input
                                                                         id="subCategory"
+                                                                        list="admin-update-subcategory-list"
                                                                         value={formData.subCategory}
                                                                         onChange={(e) =>
                                                                                 setFormData({
@@ -328,6 +330,16 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                                                                         }
                                                                         className="mt-1"
                                                                 />
+                                                                <datalist id="admin-update-subcategory-list">
+                                                                        {categories
+                                                                                .find(
+                                                                                        (cat) =>
+                                                                                                cat.slug ===
+                                                                                                formData.category
+                                                                                )?.subCategories?.map((sub) => (
+                                                                                        <option key={sub} value={sub} />
+                                                                                ))}
+                                                                </datalist>
                                                         </div>
 
 


### PR DESCRIPTION
## Summary
- merge bulk-uploaded products into existing categories and record duplicates
- allow creating and updating categories with comma-separated subcategories
- enable product forms and bulk upload popups to manage subcategories and show duplicate mappings
