### PR TITLE
feat: handle Google Drive image URLs

### DIFF
--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -22,6 +22,7 @@ import {
         TableHeader,
         TableRow,
 } from "@/components/ui/table";
+import { getDirectGoogleDriveImageUrl } from "@/lib/utils";
 
 export function BulkUploadPopup({ open, onOpenChange }) {
         const { bulkUploadProducts } = useAdminProductStore();
@@ -97,7 +98,9 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                 subCategory: row["Sub Category"] || row["Sub-Category"],
                                 price: row["Price"],
                                 mrp: row["MRP"],
-                                mainImageLink: row["Main Image Link"],
+                                mainImageLink: getDirectGoogleDriveImageUrl(
+                                        row["Main Image Link"]
+                                ),
                                 length: row["Length (mm)"],
                                 width: row["Width (mm)"],
                                 height: row["height (mm)"],

--- a/components/BuyerPanel/products/ProductDetail.jsx
+++ b/components/BuyerPanel/products/ProductDetail.jsx
@@ -34,14 +34,27 @@ import { toast } from "react-hot-toast";
 import Image from "next/image";
 import { useIsAuthenticated } from "@/store/authStore";
 import ReviewAndRatings from "./ReviewAndRatings";
+import { getDirectGoogleDriveImageUrl } from "@/lib/utils";
 
 export default function ProductDetail({ product, relatedProducts = [] }) {
 	const [selectedImage, setSelectedImage] = useState(0);
 	const [quantity, setQuantity] = useState(1);
-	const [selectedQuantityOffer, setSelectedQuantityOffer] = useState(null);
-	const router = useRouter();
-	const isAuthenticated = useIsAuthenticated();
-	const { addItem, isLoading } = useCartStore();
+        const [selectedQuantityOffer, setSelectedQuantityOffer] = useState(null);
+        const router = useRouter();
+        const isAuthenticated = useIsAuthenticated();
+        const { addItem, isLoading } = useCartStore();
+
+        const fallbackMainImage =
+                "https://res.cloudinary.com/drjt9guif/image/upload/v1755168534/safetyonline_fks0th.png";
+        const fallbackThumbImage =
+                "https://res.cloudinary.com/drjt9guif/image/upload/v1755848946/ladwapartnersfallback_s5zjgs.png";
+
+        const mainImageSrc = getDirectGoogleDriveImageUrl(
+                product.images?.[selectedImage] ||
+                        product.image ||
+                        fallbackMainImage
+        );
+        const isMainImageUnoptimized = mainImageSrc.includes("google");
 
 	// Mock reviews data - you can replace this with real reviews from the API
 	const reviews = [
@@ -182,19 +195,18 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
 						{/* Product Images Section */}
 						<div className="relative">
 							{/* Main Product Image */}
-							<div className="relative bg-gray-50 rounded-lg overflow-hidden">
-								<div className="relative h-96 md:h-[66vh]">
-									<img
-										src={
-											product.images?.[selectedImage] ||
-											product.image ||
-											"https://res.cloudinary.com/drjt9guif/image/upload/v1755168534/safetyonline_fks0th.png"
-										}
-										alt={product.name}
-										className="w-full h-full object-contain p-8"
-									/>
-								</div>
-							</div>
+                                                        <div className="relative bg-gray-50 rounded-lg overflow-hidden">
+                                                                <div className="relative h-96 md:h-[66vh]">
+                                                                        <Image
+                                                                                src={mainImageSrc}
+                                                                                alt={product.name}
+                                                                                fill
+                                                                                sizes="100vw"
+                                                                                className="object-contain p-8"
+                                                                                unoptimized={isMainImageUnoptimized}
+                                                                        />
+                                                                </div>
+                                                        </div>
 
 							{/* Share and Wishlist Icons - positioned on right side */}
 							<div className="absolute top-0 right-0 flex flex-col items-center space-y-2 p-2">
@@ -217,27 +229,34 @@ export default function ProductDetail({ product, relatedProducts = [] }) {
 							</div>
 
 							{/* Thumbnail Images */}
-							<div className="flex gap-2 mt-4">
-								{product.images?.slice(0, 4).map((image, index) => (
-									<button
-										key={index}
-										onClick={() => setSelectedImage(index)}
-										className={`relative w-16 h-16 md:w-20 md:h-20 border rounded-lg overflow-hidden flex-shrink-0 ${selectedImage === index
-											? "border-blue-500"
-											: "border-gray-200 hover:border-gray-300"
-											}`}
-									>
-										<img
-											src={
-												image ||
-												"https://res.cloudinary.com/drjt9guif/image/upload/v1755848946/ladwapartnersfallback_s5zjgs.png"
-											}
-											alt={`${product.name} view ${index + 1}`}
-											className="w-full h-full object-contain p-1"
-										/>
-									</button>
-								))}
-							</div>
+                                                        <div className="flex gap-2 mt-4">
+                                                                {product.images?.slice(0, 4).map((image, index) => {
+                                                                        const src = getDirectGoogleDriveImageUrl(
+                                                                                image ||
+                                                                                        fallbackThumbImage
+                                                                        );
+                                                                        const unopt = src.includes("google");
+                                                                        return (
+                                                                                <button
+                                                                                        key={index}
+                                                                                        onClick={() => setSelectedImage(index)}
+                                                                                        className={`relative w-16 h-16 md:w-20 md:h-20 border rounded-lg overflow-hidden flex-shrink-0 ${selectedImage === index
+                                                                                                ? "border-blue-500"
+                                                                                                : "border-gray-200 hover:border-gray-300"
+                                                                                                }`}
+                                                                                >
+                                                                                        <Image
+                                                                                                src={src}
+                                                                                                alt={`${product.name} view ${index + 1}`}
+                                                                                                fill
+                                                                                                sizes="80px"
+                                                                                                className="object-contain p-1"
+                                                                                                unoptimized={unopt}
+                                                                                        />
+                                                                                </button>
+                                                                        );
+                                                                })}
+                                                        </div>
 						</div>
 
 						{/* Product Details Section */}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,3 +4,23 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+// Converts a Google Drive share link into a direct image URL
+// Example:
+//  https://drive.google.com/file/d/FILE_ID/view?usp=sharing
+// becomes:
+//  https://drive.usercontent.google.com/download?id=FILE_ID&export=view&authuser=0
+export function getDirectGoogleDriveImageUrl(url) {
+  if (!url) return url;
+
+  try {
+    const match = url.match(/(?:file\/d\/|id=)([a-zA-Z0-9_-]+)/);
+    if (match && match[1]) {
+      return `https://drive.usercontent.google.com/download?id=${match[1]}&export=view&authuser=0`;
+    }
+  } catch (e) {
+    // ignore and fall back to original url
+  }
+
+  return url;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	images: {
-		domains: ["res.cloudinary.com", "ladwas.com"],
-	},
+        images: {
+                domains: ["res.cloudinary.com", "ladwas.com"],
+                remotePatterns: [
+                        {
+                                protocol: "https",
+                                hostname: "drive.usercontent.google.com",
+                                pathname: "/**",
+                        },
+                        {
+                                protocol: "https",
+                                hostname: "lh*.googleusercontent.com",
+                                pathname: "/**",
+                        },
+                ],
+        },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- convert Google Drive share links into direct image URLs
- use the helper for product details and bulk CSV upload
- allow Google Drive and Googleusercontent domains for Next.js images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(Cannot serialize key "parse" in parser: Function values are not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ada3b87bb8832e8caf48834f8139e4