### PR TITLE
Link navbar to Home and About Us section

### DIFF
--- a/components/BuyerPanel/NavigationBar.jsx
+++ b/components/BuyerPanel/NavigationBar.jsx
@@ -45,8 +45,8 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
       .replace(/(^-|-$)+/g, "");
 
   const staticItems = [
-    { id: "home", label: "Home", href: "/" },
-    { id: "about-us", label: "About us", href: "/about" },
+    { id: "home", label: "Home", href: "/home" },
+    { id: "about-us", label: "About us", href: "/home#about-us" },
   ];
 
   const orderedSlugs = [
@@ -77,7 +77,11 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
   };
 
   const handleNavigation = (href) => {
-    router.push(href);
+    if (href.includes("#")) {
+      window.location.href = href;
+    } else {
+      router.push(href);
+    }
     if (onMenuClose) onMenuClose();
   };
 

--- a/components/BuyerPanel/home/AboutUsLadwaPartners.jsx
+++ b/components/BuyerPanel/home/AboutUsLadwaPartners.jsx
@@ -101,7 +101,8 @@ const AboutUsLadwaPartners = () => {
   }
 
   return (
-    <motion.div 
+    <motion.div
+      id="about-us"
       className="bg-gray-50 py-16 px-4"
       variants={containerVariants}
       initial="hidden"
@@ -212,7 +213,7 @@ const AboutUsLadwaPartners = () => {
         </div>
       </div>
     </motion.div>
-  )
-}
+  );
+};
 
-export default AboutUsLadwaPartners
+export default AboutUsLadwaPartners;


### PR DESCRIPTION
## Summary
- Update navbar links so Home directs to `/home` and About Us anchors to the home page's about section.
- Add in-page anchor handling and ID for about section component for navigation.
