### PR TITLE
Allow toggling navigation bar on desktop

### DIFF
--- a/app/(buyers)/layout.js
+++ b/app/(buyers)/layout.js
@@ -9,7 +9,7 @@ import { useState } from "react";
 export default function BuyersPanelLayout({ children }) {
   const pathname = usePathname();
   const showFooter = pathname === "/home" || pathname === "/cart";
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(true);
 
   return (
     <div className="relative">

--- a/components/BuyerPanel/NavigationBar.jsx
+++ b/components/BuyerPanel/NavigationBar.jsx
@@ -18,7 +18,6 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
   const [searchQuery, setSearchQuery] = useState("");
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [categoryData, setCategoryData] = useState([]);
-  const [isDesktop, setIsDesktop] = useState(false);
   const router = useRouter();
   const {
     setSearchQuery: setGlobalSearch,
@@ -39,13 +38,6 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
     fetchCategories();
   }, []);
 
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(min-width: 1024px)");
-    const handleChange = (e) => setIsDesktop(e.matches);
-    handleChange(mediaQuery);
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
-  }, []);
 
   const slugify = (text) =>
     text
@@ -111,9 +103,9 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
 
   return (
     <AnimatePresence initial={false}>
-      {(isMenuOpen || isDesktop) && (
+      {isMenuOpen && (
         <motion.nav
-          initial={isDesktop ? false : { height: 0, opacity: 0 }}
+          initial={{ height: 0, opacity: 0 }}
           animate={{ height: "auto", opacity: 1 }}
           exit={{ height: 0, opacity: 0 }}
           transition={{ duration: 0.3 }}


### PR DESCRIPTION
## Summary
- Allow buyer layout navigation to start open and toggle via hamburger
- Remove desktop-only always-open logic so bar can be closed on large screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*

------
https://chatgpt.com/codex/tasks/task_e_68aea0e30500832eb11dbad95887ff95