### PR TITLE
Enable search submission from navigation bar

### DIFF
--- a/app/(buyers)/products/page.jsx
+++ b/app/(buyers)/products/page.jsx
@@ -14,22 +14,20 @@ export default function ProductsPage() {
         const { error, fetchProducts, setCurrentCategory, setSearchQuery } =
                 useProductStore();
 
-	// Handle URL parameters
-	useEffect(() => {
+        // Handle URL parameters
+        useEffect(() => {
                 const category = searchParams.get("category");
                 const subCategory = searchParams.get("subCategory");
                 const search = searchParams.get("search");
 
-                if (category || subCategory) {
+                if (search) {
+                        setSearchQuery(search);
+                } else if (category || subCategory) {
                         setCurrentCategory(category || "all", subCategory || "");
+                } else {
+                        fetchProducts();
                 }
-
-		if (search) {
-			setSearchQuery(search);
-		}
-
-		fetchProducts();
-	}, [searchParams, fetchProducts, setCurrentCategory, setSearchQuery]);
+        }, [searchParams, fetchProducts, setCurrentCategory, setSearchQuery]);
 
 	if (error) {
 		return (

--- a/components/BuyerPanel/NavigationBar.jsx
+++ b/components/BuyerPanel/NavigationBar.jsx
@@ -22,9 +22,14 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
   const router = useRouter();
   const {
     setSearchQuery: setGlobalSearch,
+    searchQuery: globalSearch,
     currentCategory,
     setCurrentCategory,
   } = useProductStore();
+
+  useEffect(() => {
+    setSearchQuery(globalSearch);
+  }, [globalSearch]);
 
   useEffect(() => {
     const fetchCategories = async () => {
@@ -188,11 +193,18 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
             <div className="relative">
               <Input
                 placeholder="Search products..."
-                className="w-64 pr-10"
+                className="w-64 pr-12"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
-              <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Button
+                type="submit"
+                size="icon"
+                variant="ghost"
+                className="absolute right-1 top-1/2 -translate-y-1/2"
+              >
+                <Search className="h-4 w-4 text-gray-400" />
+              </Button>
             </div>
           </form>
 
@@ -219,11 +231,18 @@ export default function NavigationBar({ isMenuOpen, onMenuClose }) {
               <div className="relative py-2">
                 <Input
                   placeholder="Search products..."
-                  className="w-full md:w-64"
+                  className="w-full md:w-64 pr-12"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                 />
-                <Search className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Button
+                  type="submit"
+                  size="icon"
+                  variant="ghost"
+                  className="absolute right-1 top-1/2 -translate-y-1/2"
+                >
+                  <Search className="h-4 w-4 text-gray-400" />
+                </Button>
               </div>
             </motion.form>
           )}

--- a/components/BuyerPanel/products/ProductGrid.jsx
+++ b/components/BuyerPanel/products/ProductGrid.jsx
@@ -27,16 +27,17 @@ import ProductFilters from "@/components/BuyerPanel/products/ProductFilters.jsx"
 export default function ProductGrid() {
 	const [viewMode, setViewMode] = useState("grid");
 
-	const {
-		filteredProducts,
-		currentPage,
-		totalPages,
-		isLoading,
-		setCurrentPage,
-		setSorting,
-		sortBy,
-		sortOrder,
-	} = useProductStore();
+        const {
+                filteredProducts,
+                currentPage,
+                totalPages,
+                isLoading,
+                searchQuery,
+                setCurrentPage,
+                setSorting,
+                sortBy,
+                sortOrder,
+        } = useProductStore();
 
 	const handlePageChange = (page) => {
 		setCurrentPage(page);
@@ -58,12 +59,16 @@ export default function ProductGrid() {
 			<div className="bg-white rounded-lg p-6 shadow-sm">
 				<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
 					<div>
-						<h1 className="text-3xl font-bold text-gray-900">Products</h1>
-						<p className="text-gray-600 mt-1">
-							{isLoading
-								? "Loading products..."
-								: `Showing ${filteredProducts.length} products`}
-						</p>
+                                                <h1 className="text-3xl font-bold text-gray-900">
+                                                        {searchQuery
+                                                                ? `Results for "${searchQuery}"`
+                                                                : "Products"}
+                                                </h1>
+                                                <p className="text-gray-600 mt-1">
+                                                        {isLoading
+                                                                ? "Loading products..."
+                                                                : `Showing ${filteredProducts.length} products`}
+                                                </p>
 					</div>
 
 					<div className="flex items-center gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
- Sync navigation bar search field with global store so queries persist across pages
- Show matching product results and headings based on URL search parameters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68aea0aba244832e8ab99521885b6133