### PR TITLE
Add wishlist page and link from header

### DIFF
--- a/app/(buyers)/wishlist/page.jsx
+++ b/app/(buyers)/wishlist/page.jsx
@@ -1,0 +1,7 @@
+"use client";
+
+import WishlistPage from "@/components/BuyerPanel/wishlist/WishlistPage";
+
+export default function Wishlist() {
+        return <WishlistPage />;
+}

--- a/components/BuyerPanel/Header.jsx
+++ b/components/BuyerPanel/Header.jsx
@@ -116,9 +116,15 @@ export default function Header({ onMenuToggle, isMenuOpen }) {
                                                                 </span>
                                                         )}
                                                 </Button>
-                                                <Button variant="ghost" size="icon" className="bg-white rounded-full">
-                                                        <Heart className="h-5 w-5 md:h-6 md:w-6" />
-                                                </Button>
+                                                <Link href="/wishlist">
+                                                        <Button
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="bg-white rounded-full"
+                                                        >
+                                                                <Heart className="h-5 w-5 md:h-6 md:w-6" />
+                                                        </Button>
+                                                </Link>
                                         </>
                                 )}
 

--- a/components/BuyerPanel/wishlist/WishlistPage.jsx
+++ b/components/BuyerPanel/wishlist/WishlistPage.jsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import Image from "next/image";
+import { Trash2, ArrowLeft, ShoppingCart } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCartStore } from "@/store/cartStore";
+
+export default function WishlistPage() {
+        const router = useRouter();
+        const { addItem } = useCartStore();
+        const [items, setItems] = useState([]);
+
+        useEffect(() => {
+                if (typeof window === "undefined") return;
+                const stored = JSON.parse(localStorage.getItem("wishlist") || "[]");
+                setItems(stored);
+        }, []);
+
+        const removeItem = (id) => {
+                const updated = items.filter((i) => i.id !== id);
+                setItems(updated);
+                if (typeof window !== "undefined") {
+                        localStorage.setItem("wishlist", JSON.stringify(updated));
+                }
+        };
+
+        const moveToCart = (item) => {
+                addItem(item, 1);
+                removeItem(item.id);
+        };
+
+        const handleGoBack = () => router.back();
+
+        return (
+                <div className="min-h-screen bg-gray-50">
+                        <div className="container mx-auto px-4 py-8">
+                                <div className="flex items-center gap-4 mb-8">
+                                        <Button variant="outline" size="icon" onClick={handleGoBack}>
+                                                <ArrowLeft className="h-4 w-4" />
+                                        </Button>
+                                        <h1 className="text-3xl font-bold">Wishlist</h1>
+                                </div>
+                                {items.length === 0 ? (
+                                        <Card className="max-w-md mx-auto">
+                                                <CardContent className="p-8 text-center">
+                                                        <p className="text-gray-600">Your wishlist is empty.</p>
+                                                </CardContent>
+                                        </Card>
+                                ) : (
+                                        <div className="space-y-4">
+                                                {items.map((item) => (
+                                                        <Card key={item.id}>
+                                                                <CardContent className="flex items-center justify-between p-4">
+                                                                        <div className="flex items-center gap-4">
+                                                                                <div className="relative w-16 h-16">
+                                                                                        <Image
+                                                                                                src={
+                                                                                                        item.image ||
+                                                                                                        "https://res.cloudinary.com/drjt9guif/image/upload/v1755848946/ladwapartnersfallback_s5zjgs.png"
+                                                                                                }
+                                                                                                alt={item.name}
+                                                                                                fill
+                                                                                                className="object-contain"
+                                                                                        />
+                                                                                </div>
+                                                                                <div>
+                                                                                        <h3 className="font-semibold">{item.name}</h3>
+                                                                                        <p className="text-sm text-gray-600">
+                                                                                                ₹{item.price?.toLocaleString()}
+                                                                                        </p>
+                                                                                </div>
+                                                                        </div>
+                                                                        <div className="flex items-center gap-2">
+                                                                                <Button
+                                                                                        variant="outline"
+                                                                                        size="icon"
+                                                                                        onClick={() => removeItem(item.id)}
+                                                                                >
+                                                                                        <Trash2 className="h-4 w-4" />
+                                                                                </Button>
+                                                                                <Button size="sm" onClick={() => moveToCart(item)}>
+                                                                                        <ShoppingCart className="h-4 w-4 mr-2" />
+                                                                                        Add to Cart
+                                                                                </Button>
+                                                                        </div>
+                                                                </CardContent>
+                                                        </Card>
+                                                ))}
+                                        </div>
+                                )}
+                        </div>
+                </div>
+        );
+}


### PR DESCRIPTION
## Summary
- link the header heart button to the new /wishlist route
- add client-side wishlist page that reads items from localStorage and allows moving to cart or removal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot serialize key "parse" in parser: Function values are not supported.)

------
https://chatgpt.com/codex/tasks/task_e_68aefc0917d4832ebd6933f404ea8260