### PR TITLE
Remove Payment Options from account sidebar

### DIFF
--- a/app/(buyers)/account/layout.js
+++ b/app/(buyers)/account/layout.js
@@ -26,7 +26,6 @@ export default function AccountLayout({ children }) {
 				"/account": "my-profile",
 				"/account/profile": "my-profile",
 				"/account/orders": "order-history",
-				"/account/payment": "payment-options",
 				"/account/notifications": "notification-settings",
 				"/account/help": "help-center",
 			};

--- a/components/BuyerPanel/account/AccountContent.jsx
+++ b/components/BuyerPanel/account/AccountContent.jsx
@@ -3,7 +3,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { OrderHistory } from "@/components/account/tabs/OrderHistory.jsx";
 import { MyProfile } from "@/components/account/tabs/MyProfile.jsx";
-import { PaymentOptions } from "@/components/account/tabs/PaymentOptions.jsx";
 import { NotificationSettings } from "@/components/account/tabs/NotificationSettings.jsx";
 import { HelpCenter } from "@/components/account/tabs/HelpCenter.jsx";
 
@@ -17,7 +16,6 @@ const contentVariants = {
 const tabComponents = {
 	"order-history": OrderHistory,
 	"my-profile": MyProfile,
-	"payment-options": PaymentOptions,
 	"notification-settings": NotificationSettings,
 	"help-center": HelpCenter,
 };

--- a/components/BuyerPanel/account/AccountSidebar.jsx
+++ b/components/BuyerPanel/account/AccountSidebar.jsx
@@ -2,7 +2,7 @@
 
 import { motion } from "framer-motion";
 import { useRouter, usePathname } from "next/navigation";
-import { Package, User, CreditCard, Bell, HelpCircle } from "lucide-react";
+import { Package, User, Bell, HelpCircle } from "lucide-react";
 
 const sidebarItems = [
 	{
@@ -18,13 +18,6 @@ const sidebarItems = [
 		icon: Package,
 		description: "View your past orders",
 		href: "/account/orders",
-	},
-	{
-		id: "payment-options",
-		title: "Payment Options",
-		icon: CreditCard,
-		description: "Cards, wallets & UPI",
-		href: "/account/payment",
 	},
 	{
 		id: "notification-settings",


### PR DESCRIPTION
## Summary
- Hide the Payment Options link in the user account sidebar.
- Update account layout mapping and content to drop unused Payment Options tab.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sweetalert2)*

------
https://chatgpt.com/codex/tasks/task_e_68af14403e94832e8a516ee453bfa954