### PR TITLE
fix: persist admin session after login

### DIFF
--- a/app/admin/(auth)/login/page.jsx
+++ b/app/admin/(auth)/login/page.jsx
@@ -32,13 +32,18 @@ export default function Login() {
         headers: {
           "Content-Type": "application/json",
         },
+        // Ensure cookies are persisted and sent with the request
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
 
       const data = await res.json();
 
       if (res.ok) {
-        const userResponse = await fetch("/api/admin/auth/me");
+        // Fetch the logged in user information with credentials
+        const userResponse = await fetch("/api/admin/auth/me", {
+            credentials: "include",
+        });
         if (userResponse.ok) {
             const userData = await userResponse.json();
             setAdminUser(userData.user);


### PR DESCRIPTION
## Summary
- ensure admin login sets and sends auth cookie
- fetch admin profile with credentials to populate auth store

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68af24898a1c832e94a0e96e826aa368