### PR TITLE
Authorize admin panel by user type

### DIFF
--- a/app/api/admin/auth/me/route.js
+++ b/app/api/admin/auth/me/route.js
@@ -4,25 +4,26 @@ import { verifyToken } from "@/lib/auth";
 import { cookies } from "next/headers";
 
 export async function GET() {
-	await dbConnect();
+        await dbConnect();
 
-	try {
-		const cookieStore = await cookies();
-		const token = cookieStore.get("auth_token")?.value;
+        try {
+                const cookieStore = await cookies();
+                const token = cookieStore.get("auth_token")?.value;
 
-		if (!token) {
-			return Response.json({ message: "No token provided" }, { status: 401 });
-		}
+                if (!token) {
+                        return Response.json({ message: "No token provided" }, { status: 401 });
+                }
 
-		const decoded = verifyToken(token);
-		const user = await User.findById(decoded.id).select("-password");
+                const decoded = verifyToken(token);
 
-		if (!user) {
-			return Response.json({ message: "User  not found" }, { status: 404 });
-		}
+                const user = await User.findById(decoded.id).select("-password");
 
-		return Response.json({ user });
-	} catch (error) {
-		return Response.json({ message: "Invalid token" }, { status: 401 });
-	}
+                if (!user || user.userType !== "admin") {
+                        return Response.json({ message: "Unauthorized" }, { status: 403 });
+                }
+
+                return Response.json({ user });
+        } catch (error) {
+                return Response.json({ message: "Invalid token" }, { status: 401 });
+        }
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,6 +9,7 @@ export function createToken(user, expiresIn = "3d") {
                         email: user.email,
                         firstName: user.firstName,
                         lastName: user.lastName,
+                        userType: user.userType,
                 },
                 JWT_SECRET,
                 { expiresIn }

--- a/middleware.js
+++ b/middleware.js
@@ -1,19 +1,52 @@
 import { NextResponse } from "next/server";
 import { verifyToken } from "@/lib/auth";
-import { cookies } from "next/headers";
 
 export function middleware(req) {
-	const token = req.cookies.get("auth_token")?.value;
+        const token = req.cookies.get("auth_token")?.value;
+        const { pathname } = req.nextUrl;
 
-	try {
-		verifyToken(token);
-		return NextResponse.next();
-	} catch {
-		return NextResponse.redirect(new URL("/login", req.url));
-	}
+        // Allow access to public admin auth routes
+        const adminAuthPaths = [
+                "/admin/login",
+                "/admin/signup",
+                "/api/admin/auth/login",
+                "/api/admin/auth/register",
+        ];
+        if (adminAuthPaths.some((p) => pathname.startsWith(p))) {
+                return NextResponse.next();
+        }
+
+        try {
+                const decoded = verifyToken(token);
+
+                // Additional checks for admin-only routes
+                if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
+                        if (decoded.userType !== "admin") {
+                                if (pathname.startsWith("/api")) {
+                                        return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+                                }
+                                return NextResponse.redirect(new URL("/admin/login", req.url));
+                        }
+                }
+
+                return NextResponse.next();
+        } catch {
+                if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
+                        if (pathname.startsWith("/api")) {
+                                return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+                        }
+                        return NextResponse.redirect(new URL("/admin/login", req.url));
+                }
+                return NextResponse.redirect(new URL("/login", req.url));
+        }
 }
 
 // Apply to protected routes
 export const config = {
-	matcher: ["/dashboard/:path*", "/account"],
+        matcher: [
+                "/dashboard/:path*",
+                "/account",
+                "/admin/:path*",
+                "/api/admin/:path*",
+        ],
 };


### PR DESCRIPTION
## Summary
- Allow admin login for any `admin` user type and redirect to `/admin/dashboard`
- Verify admin status in `/api/admin/auth/me` and middleware using `userType`
- Include `userType` field in JWT tokens for role-aware checks
