### PR TITLE
Fix admin login endpoint response

### DIFF
--- a/app/api/admin/auth/login/route.js
+++ b/app/api/admin/auth/login/route.js
@@ -16,7 +16,7 @@ export async function POST(req) {
                 user.userType !== "admin" ||
                 !(await user.comparePassword(password))
         ) {
-                return Response.json({ message: "Unauthorized" }, { status: 401 });
+                return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
         }
 
 
@@ -31,7 +31,7 @@ export async function POST(req) {
         });
 
 
-        const res = NextResponse.redirect(new URL("/admin/dashboard", req.url));
+        const res = NextResponse.json({ message: "Login successful" });
         res.headers.set("Set-Cookie", cookie);
         return res;
 


### PR DESCRIPTION
## Summary
- return JSON from admin login endpoint instead of redirect
- use NextResponse.json for unauthorized response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af28de6ac0832eb6c43a2d30dbe4ed