### PR TITLE
fix: verify admin token in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,54 @@
 import { NextResponse } from "next/server";
-import { verifyToken } from "@/lib/auth";
 
-export function middleware(req) {
+async function verifyJwt(token) {
+        try {
+                const secret = new TextEncoder().encode(
+                        process.env.JWT_SECRET || "your-secret-key",
+                );
+                const [headerB64, payloadB64, signatureB64] = token.split(".");
+                const data = `${headerB64}.${payloadB64}`;
+
+                const key = await crypto.subtle.importKey(
+                        "raw",
+                        secret,
+                        { name: "HMAC", hash: "SHA-256" },
+                        false,
+                        ["verify"],
+                );
+                const signature = base64UrlToUint8Array(signatureB64);
+                const valid = await crypto.subtle.verify(
+                        "HMAC",
+                        key,
+                        signature,
+                        new TextEncoder().encode(data),
+                );
+
+                if (!valid) {
+                        return null;
+                }
+
+                const payloadJSON = new TextDecoder().decode(
+                        base64UrlToUint8Array(payloadB64),
+                );
+                return JSON.parse(payloadJSON);
+        } catch {
+                return null;
+        }
+}
+
+function base64UrlToUint8Array(str) {
+        const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+        const pad = base64.length % 4;
+        const padded = base64 + (pad ? "=".repeat(4 - pad) : "");
+        const binary = atob(padded);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+}
+
+export async function middleware(req) {
         const token = req.cookies.get("auth_token")?.value;
         const { pathname } = req.nextUrl;
 
@@ -16,31 +63,28 @@ export function middleware(req) {
                 return NextResponse.next();
         }
 
-        try {
-                const decoded = verifyToken(token);
+        const decoded = token ? await verifyJwt(token) : null;
 
+        if (decoded) {
                 // Additional checks for admin-only routes
                 if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
-
                         if (decoded.userType !== "admin") {
-
                                 if (pathname.startsWith("/api")) {
                                         return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
                                 }
                                 return NextResponse.redirect(new URL("/admin/login", req.url));
                         }
                 }
-
                 return NextResponse.next();
-        } catch {
-                if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
-                        if (pathname.startsWith("/api")) {
-                                return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
-                        }
-                        return NextResponse.redirect(new URL("/admin/login", req.url));
-                }
-                return NextResponse.redirect(new URL("/login", req.url));
         }
+
+        if (pathname.startsWith("/admin") || pathname.startsWith("/api/admin")) {
+                if (pathname.startsWith("/api")) {
+                        return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+                }
+                return NextResponse.redirect(new URL("/admin/login", req.url));
+        }
+        return NextResponse.redirect(new URL("/login", req.url));
 }
 
 // Apply to protected routes


### PR DESCRIPTION
## Summary
- handle admin auth token in middleware using edge-compatible crypto
- return unauthorized responses when verification fails
