### PR TITLE
fix: ensure category navigation fetches products

### DIFF
--- a/app/(buyers)/products/page.jsx
+++ b/app/(buyers)/products/page.jsx
@@ -10,39 +10,40 @@ import { useSearchParams } from "next/navigation";
 export default function ProductsPage() {
 	const searchParams = useSearchParams();
 
-	const {
-		error,
-		fetchProducts,
-		setCurrentCategory,
-		setSearchQuery,
-		setFilters,
-	} = useProductStore();
+        const {
+                error,
+                fetchProducts,
+                setCurrentCategory,
+                setSearchQuery,
+                setFilters,
+        } = useProductStore();
 
-	// Handle URL parameters
-	useEffect(() => {
-		const category = searchParams.get("category");
-		const subCategory = searchParams.get("subCategory");
-		const search = searchParams.get("search");
+        // Handle URL parameters
+        useEffect(() => {
+                const category = searchParams.get("category");
+                const subCategory = searchParams.get("subCategory");
+                const search = searchParams.get("search");
 
-		if (search) {
-			setSearchQuery(search);
-		} else if (category || subCategory) {
-			if (category && !subCategory) {
-				setFilters({ categories: [category] });
-			} else {
-				setFilters({ categories: [] });
-			}
-			setCurrentCategory(category || "all", subCategory || "");
-		} else {
-			fetchProducts();
-		}
-	}, [
-		searchParams,
-		fetchProducts,
-		setCurrentCategory,
-		setSearchQuery,
-		setFilters,
-	]);
+                if (search) {
+                        // Searching triggers its own fetch inside setSearchQuery
+                        setSearchQuery(search);
+                } else {
+                        // Apply category filters first, then update store and fetch
+                        if (category && !subCategory) {
+                                setFilters({ categories: [category] });
+                        } else {
+                                setFilters({ categories: [] });
+                        }
+                        setCurrentCategory(category || "all", subCategory || "");
+                        fetchProducts();
+                }
+        }, [
+                searchParams,
+                fetchProducts,
+                setCurrentCategory,
+                setSearchQuery,
+                setFilters,
+        ]);
 
 	if (error) {
 		return (

--- a/store/productStore.js
+++ b/store/productStore.js
@@ -135,12 +135,14 @@ export const useProductStore = create(
 				},
 
                                 setCurrentCategory: (category, subCategory = "") => {
+                                        // Only update state here. Fetching will be handled explicitly
+                                        // after related filters are applied to avoid race conditions
+                                        // where outdated filters could lead to empty product lists.
                                         set({
                                                 currentCategory: category,
                                                 currentSubCategory: subCategory,
                                                 currentPage: 1,
                                         });
-                                        get().fetchProducts();
                                 },
 
 				setCurrentPage: (page) => {


### PR DESCRIPTION
## Summary
- avoid race conditions by separating category state updates from fetching
- load products after applying category filters on the products page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sweetalert2)*

------
https://chatgpt.com/codex/tasks/task_e_68b14ed3a4bc832eb21d50659d8d3705