### PR TITLE
Use rupee symbol for all prices

### DIFF
--- a/app/admin/international/currencies/page.jsx
+++ b/app/admin/international/currencies/page.jsx
@@ -22,30 +22,12 @@ import { useIsAuthenticated } from "@/store/adminAuthStore.js";
 import { useRouter } from "next/navigation";
 
 const currencies = [
-	{
-		id: 1,
-		name: "Dollar",
-		symbol: "$",
-		published: true,
-	},
-	{
-		id: 2,
-		name: "Euro",
-		symbol: "€",
-		published: true,
-	},
-	{
-		id: 3,
-		name: "Pound",
-		symbol: "£",
-		published: true,
-	},
-	{
-		id: 4,
-		name: "Yen",
-		symbol: "¥",
-		published: true,
-	},
+        {
+                id: 1,
+                name: "Indian Rupee",
+                symbol: "₹",
+                published: true,
+        },
 ];
 
 export default function CurrenciesPage() {

--- a/app/admin/store/view/page.jsx
+++ b/app/admin/store/view/page.jsx
@@ -27,7 +27,7 @@ export default function ViewStorePage() {
 		categories: 12,
 		orders: 89,
 		visitors: 1247,
-		revenue: "$12,450",
+                revenue: "₹12,450",
 		conversionRate: "3.2%",
 	});
 

--- a/components/AdminPanel/AdminSidebar.jsx
+++ b/components/AdminPanel/AdminSidebar.jsx
@@ -42,10 +42,9 @@ import {
 	Layers,
 	Ticket,
 	Languages,
-	DollarSign,
-	Eye,
-	Palette,
-	Cog,
+        Eye,
+        Palette,
+        Cog,
 } from "lucide-react";
 import Logo from "@/public/ladwapartners.png";
 import { useIsAuthenticated } from "@/store/adminAuthStore.js";
@@ -103,7 +102,7 @@ const menuItems = [
 	// 		{
 	// 			title: "Currencies",
 	// 			href: "/admin/international/currencies",
-	// 			icon: DollarSign,
+	// 			icon: IndianRupee,
 	// 		},
 	// 	],
 	// },

--- a/components/AdminPanel/Dashboard/AdminDashboard.jsx
+++ b/components/AdminPanel/Dashboard/AdminDashboard.jsx
@@ -5,11 +5,11 @@ import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
-	Package,
-	ShoppingCart,
-	Users,
-	DollarSign,
-	AlertTriangle,
+        Package,
+        ShoppingCart,
+        Users,
+        IndianRupee,
+        AlertTriangle,
 	CheckCircle,
 	Clock,
 	Store,
@@ -131,7 +131,7 @@ export default function AdminDashboard() {
 					title="Total Revenue"
 					value={`₹${data.overview.totalRevenue.toLocaleString()}`}
 					change={data.overview.revenueGrowth}
-					icon={DollarSign}
+                                        icon={IndianRupee}
 					color="green"
 					delay={0.2}
 				/>

--- a/components/AdminPanel/OrderPage.jsx
+++ b/components/AdminPanel/OrderPage.jsx
@@ -24,19 +24,19 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import {
-	Calendar,
-	Search,
-	Download,
-	Filter,
-	RotateCcw,
-	Eye,
-	Printer,
-	Edit,
-	Trash2,
-	Package,
-	DollarSign,
-	Clock,
-	CheckCircle,
+        Calendar,
+        Search,
+        Download,
+        Filter,
+        RotateCcw,
+        Eye,
+        Printer,
+        Edit,
+        Trash2,
+        Package,
+        IndianRupee,
+        Clock,
+        CheckCircle,
 } from "lucide-react";
 import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 import { OrderDetailsPopup } from "@/components/AdminPanel/Popups/OrderDetailsPopup.jsx";
@@ -232,14 +232,14 @@ function OrderPage() {
 					<Card>
 						<CardContent className="p-6">
 							<div className="flex items-center">
-								<DollarSign className="h-8 w-8 text-green-600" />
+                                                                <IndianRupee className="h-8 w-8 text-green-600" />
 								<div className="ml-4">
 									<p className="text-sm font-medium text-gray-600">
 										Total Revenue
 									</p>
-									<p className="text-2xl font-bold text-gray-900">
-										${stats.totalRevenue.toFixed(2)}
-									</p>
+                                                                        <p className="text-2xl font-bold text-gray-900">
+                                                                                ₹{stats.totalRevenue.toFixed(2)}
+                                                                        </p>
 								</div>
 							</div>
 						</CardContent>
@@ -498,9 +498,9 @@ function OrderPage() {
 														</p>
 													</div>
 												</TableCell>
-												<TableCell className="font-medium text-green-600">
-													${order.totalAmount.toFixed(2)}
-												</TableCell>
+                                                                                                <TableCell className="font-medium text-green-600">
+                                                                                                        ₹{order.totalAmount.toFixed(2)}
+                                                                                                </TableCell>
 												<TableCell>
 													<Select
 														value={order.status}

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -110,9 +110,9 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 								</Badge>
 							</div>
 							<div className="text-right">
-								<p className="text-3xl font-bold text-orange-500">
-									${order.totalAmount.toFixed(2)}
-								</p>
+                                                               <p className="text-3xl font-bold text-orange-500">
+                                                                       ₹{order.totalAmount.toFixed(2)}
+                                                               </p>
 							</div>
 						</div>
 					</div>
@@ -167,12 +167,12 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 								<div className="col-span-2 text-center flex items-center justify-center">
 									{product.quantity}
 								</div>
-								<div className="col-span-2 text-center flex items-center justify-center">
-									${product.price.toFixed(2)}
-								</div>
-								<div className="col-span-2 text-right flex items-center justify-end">
-									${product.totalPrice.toFixed(2)}
-								</div>
+                                                               <div className="col-span-2 text-center flex items-center justify-center">
+                                                                       ₹{product.price.toFixed(2)}
+                                                               </div>
+                                                               <div className="col-span-2 text-right flex items-center justify-end">
+                                                                       ₹{product.totalPrice.toFixed(2)}
+                                                               </div>
 							</div>
 						))}
 					</div>
@@ -180,57 +180,57 @@ export function InvoicePopup({ open, onOpenChange, order }) {
 					{/* Totals */}
 					<div className="space-y-3">
 						<div className="flex justify-between">
-							<span>Subtotal</span>
-							<span>${order.subtotal.toFixed(2)}</span>
+                                                       <span>Subtotal</span>
+                                                       <span>₹{order.subtotal.toFixed(2)}</span>
 						</div>
                                                 {order.tax > 0 && (
                                                         <div className="space-y-1">
                                                                 <div className="flex justify-between">
-                                                                        <span>GST (18%)</span>
-                                                                        <span>${order.tax.toFixed(2)}</span>
+                                                               <span>GST (18%)</span>
+                                                               <span>₹{order.tax.toFixed(2)}</span>
                                                                 </div>
                                                                 {order.gst?.cgst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                <span>CGST (9%)</span>
-                                                                                <span>${order.gst.cgst.toFixed(2)}</span>
+                                                                               <span>CGST (9%)</span>
+                                                                               <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 {order.gst?.sgst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                <span>SGST (9%)</span>
-                                                                                <span>${order.gst.sgst.toFixed(2)}</span>
+                                                                               <span>SGST (9%)</span>
+                                                                               <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 {order.gst?.igst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                <span>IGST (18%)</span>
-                                                                                <span>${order.gst.igst.toFixed(2)}</span>
+                                                                               <span>IGST (18%)</span>
+                                                                               <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                         </div>
                                                 )}
 						{order.shippingCost > 0 && (
 							<div className="flex justify-between">
-								<span>Shipping</span>
-								<span>${order.shippingCost.toFixed(2)}</span>
+                                                       <span>Shipping</span>
+                                                       <span>₹{order.shippingCost.toFixed(2)}</span>
 							</div>
 						)}
 						{order.discount > 0 && (
 							<div className="flex justify-between text-green-600">
-								<span>Discount</span>
-								<span>-${order.discount.toFixed(2)}</span>
+                                                       <span>Discount</span>
+                                                       <span>-₹{order.discount.toFixed(2)}</span>
 							</div>
 						)}
 						{order.couponApplied && (
 							<div className="flex justify-between text-blue-600">
-								<span>Coupon ({order.couponApplied.couponCode})</span>
-								<span>-${order.couponApplied.discountAmount.toFixed(2)}</span>
+                                                       <span>Coupon ({order.couponApplied.couponCode})</span>
+                                                       <span>-₹{order.couponApplied.discountAmount.toFixed(2)}</span>
 							</div>
 						)}
 						<Separator />
 						<div className="flex justify-between font-bold text-lg">
-							<span>Total Amount</span>
-							<span>${order.totalAmount.toFixed(2)}</span>
+                                                       <span>Total Amount</span>
+                                                       <span>₹{order.totalAmount.toFixed(2)}</span>
 						</div>
 					</div>
 

--- a/components/AdminPanel/Popups/OrderDetailsPopup.jsx
+++ b/components/AdminPanel/Popups/OrderDetailsPopup.jsx
@@ -195,14 +195,14 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 											<div className="flex-1">
 												<h4 className="font-medium">{product.productName}</h4>
 												<p className="text-sm text-gray-600">
-													Quantity: {product.quantity} × $
-													{product.price.toFixed(2)}
+                                                                                                       Quantity: {product.quantity} × ₹
+                                                                                                        {product.price.toFixed(2)}
 												</p>
 											</div>
 											<div className="text-right">
-												<p className="font-medium">
-													${product.totalPrice.toFixed(2)}
-												</p>
+                                                                                               <p className="font-medium">
+                                                                                                       ₹{product.totalPrice.toFixed(2)}
+                                                                                               </p>
 											</div>
 										</div>
 									))}
@@ -245,30 +245,30 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 								<div className="space-y-3">
 									<div className="flex justify-between">
 										<span>Subtotal</span>
-										<span>${order.subtotal.toFixed(2)}</span>
+                                                                               <span>₹{order.subtotal.toFixed(2)}</span>
 									</div>
                                                                         {order.tax > 0 && (
                                                                                 <div className="space-y-1">
                                                                                         <div className="flex justify-between">
                                                                                                 <span>GST (18%)</span>
-                                                                                                <span>${order.tax.toFixed(2)}</span>
+                                                                                                <span>₹{order.tax.toFixed(2)}</span>
                                                                                         </div>
                                                                                         {order.gst?.cgst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
                                                                                                         <span>CGST (9%)</span>
-                                                                                                        <span>${order.gst.cgst.toFixed(2)}</span>
+                                                                                                        <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}
                                                                                         {order.gst?.sgst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
                                                                                                         <span>SGST (9%)</span>
-                                                                                                        <span>${order.gst.sgst.toFixed(2)}</span>
+                                                                                                        <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}
                                                                                         {order.gst?.igst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
                                                                                                         <span>IGST (18%)</span>
-                                                                                                        <span>${order.gst.igst.toFixed(2)}</span>
+                                                                                                        <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}
                                                                                 </div>
@@ -276,27 +276,27 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
 									{order.shippingCost > 0 && (
 										<div className="flex justify-between">
 											<span>Shipping</span>
-											<span>${order.shippingCost.toFixed(2)}</span>
+                                                                                       <span>₹{order.shippingCost.toFixed(2)}</span>
 										</div>
 									)}
 									{order.discount > 0 && (
 										<div className="flex justify-between text-green-600">
 											<span>Discount</span>
-											<span>-${order.discount.toFixed(2)}</span>
+                                                                                       <span>-₹{order.discount.toFixed(2)}</span>
 										</div>
 									)}
 									{order.couponApplied && (
 										<div className="flex justify-between text-blue-600">
 											<span>Coupon ({order.couponApplied.couponCode})</span>
 											<span>
-												-${order.couponApplied.discountAmount.toFixed(2)}
+                                                                                               -₹{order.couponApplied.discountAmount.toFixed(2)}
 											</span>
 										</div>
 									)}
 									<Separator />
 									<div className="flex justify-between text-lg font-bold">
 										<span>Total Amount</span>
-										<span>${order.totalAmount.toFixed(2)}</span>
+                                                                               <span>₹{order.totalAmount.toFixed(2)}</span>
 									</div>
 								</div>
 							</CardContent>

--- a/components/AdminPanel/Popups/UpdateOrderPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateOrderPopup.jsx
@@ -182,7 +182,7 @@ export function UpdateOrderPopup({ open, onOpenChange, order, onUpdate }) {
 
 						<div className="grid grid-cols-2 gap-4">
 							<div>
-								<Label htmlFor="shippingCost">Shipping Cost ($)</Label>
+                                                                <Label htmlFor="shippingCost">Shipping Cost (₹)</Label>
 								<Input
 									id="shippingCost"
 									type="number"
@@ -197,7 +197,7 @@ export function UpdateOrderPopup({ open, onOpenChange, order, onUpdate }) {
 							</div>
 
 							<div>
-								<Label htmlFor="tax">Tax ($)</Label>
+                                                                <Label htmlFor="tax">Tax (₹)</Label>
 								<Input
 									id="tax"
 									type="number"

--- a/components/BuyerPanel/account/OrderDetailsPopup.jsx
+++ b/components/BuyerPanel/account/OrderDetailsPopup.jsx
@@ -130,10 +130,10 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                                 <div className="flex-1">
                                                                                         <h4 className="font-medium">{product.productName}</h4>
                                                                                         <p className="text-sm text-gray-600">
-                                                                                                Qty: {product.quantity} × ${product.price.toFixed(2)}
+                                                                                                Qty: {product.quantity} × ₹{product.price.toFixed(2)}
                                                                                         </p>
                                                                                 </div>
-                                                                                <p className="font-medium">${product.totalPrice.toFixed(2)}</p>
+                                                                                <p className="font-medium">₹{product.totalPrice.toFixed(2)}</p>
                                                                         </div>
                                                                 ))}
                                                         </div>
@@ -148,30 +148,30 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                         <div className="space-y-2">
                                                                 <div className="flex justify-between">
                                                                         <span>Subtotal</span>
-                                                                        <span>${order.subtotal.toFixed(2)}</span>
+                                                                        <span>₹{order.subtotal.toFixed(2)}</span>
                                                                 </div>
                                                                 {order.tax > 0 && (
                                                                         <div className="space-y-1">
                                                                                 <div className="flex justify-between">
                                                                                         <span>GST (18%)</span>
-                                                                                        <span>${order.tax.toFixed(2)}</span>
+                                                                                        <span>₹{order.tax.toFixed(2)}</span>
                                                                                 </div>
                                                                                 {order.gst?.cgst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
                                                                                                 <span>CGST (9%)</span>
-                                                                                                <span>${order.gst.cgst.toFixed(2)}</span>
+                                                                                                <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}
                                                                                 {order.gst?.sgst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
                                                                                                 <span>SGST (9%)</span>
-                                                                                                <span>${order.gst.sgst.toFixed(2)}</span>
+                                                                                                <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}
                                                                                 {order.gst?.igst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
                                                                                                 <span>IGST (18%)</span>
-                                                                                                <span>${order.gst.igst.toFixed(2)}</span>
+                                                                                                <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}
                                                                         </div>
@@ -179,19 +179,19 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                 {order.shippingCost > 0 && (
                                                                         <div className="flex justify-between">
                                                                                 <span>Shipping</span>
-                                                                                <span>${order.shippingCost.toFixed(2)}</span>
+                                                                                <span>₹{order.shippingCost.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 {order.discount > 0 && (
                                                                         <div className="flex justify-between text-green-600">
                                                                                 <span>Discount</span>
-                                                                                <span>- ${order.discount.toFixed(2)}</span>
+                                                                                <span>-₹{order.discount.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 <Separator className="my-2" />
                                                                 <div className="flex justify-between font-semibold">
                                                                         <span>Total</span>
-                                                                        <span>${order.totalAmount.toFixed(2)}</span>
+                                                                        <span>₹{order.totalAmount.toFixed(2)}</span>
                                                                 </div>
                                                         </div>
                                                 </CardContent>

--- a/components/BuyerPanel/account/tabs/OrderHistory.jsx
+++ b/components/BuyerPanel/account/tabs/OrderHistory.jsx
@@ -164,7 +164,7 @@ export function OrderHistory() {
                                                                                                 {new Date(order.orderDate).toLocaleDateString()}
                                                                                         </TableCell>
                                                                                         <TableCell className="font-medium">
-                                                                                                ${order.totalAmount.toFixed(2)}
+                                                                                               ₹{order.totalAmount.toFixed(2)}
                                                                                         </TableCell>
                                                                                         <TableCell>
                                                                                                 <Badge className={getStatusColor(order.status)}>

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -181,66 +181,66 @@ const InvoiceDocument = ({ order }) => (
 						<View style={styles.tableCol}>
 							<Text style={styles.tableCell}>{product.quantity}</Text>
 						</View>
-						<View style={styles.tableCol}>
-							<Text style={styles.tableCell}>${product.price.toFixed(2)}</Text>
-						</View>
-						<View style={styles.tableCol}>
-							<Text style={styles.tableCell}>
-								${product.totalPrice.toFixed(2)}
-							</Text>
-						</View>
-					</View>
-				))}
-			</View>
+                                               <View style={styles.tableCol}>
+                                                       <Text style={styles.tableCell}>₹{product.price.toFixed(2)}</Text>
+                                               </View>
+                                               <View style={styles.tableCol}>
+                                                       <Text style={styles.tableCell}>
+                                                               ₹{product.totalPrice.toFixed(2)}
+                                                       </Text>
+                                               </View>
+                                       </View>
+                               ))}
+                       </View>
 
 			{/* Totals */}
 			<View style={styles.totalSection}>
-				<View style={styles.totalRow}>
-					<Text>Subtotal:</Text>
-					<Text>${order.subtotal.toFixed(2)}</Text>
-				</View>
-                                {order.tax > 0 && (
-                                        <View>
-                                                <View style={styles.totalRow}>
-                                                        <Text>GST (18%):</Text>
-                                                        <Text>${order.tax.toFixed(2)}</Text>
-                                                </View>
-                                                {order.gst?.cgst > 0 && (
-                                                        <View style={[styles.totalRow, { paddingLeft: 10 }]}> 
-                                                                <Text>CGST (9%):</Text>
-                                                                <Text>${order.gst.cgst.toFixed(2)}</Text>
-                                                        </View>
-                                                )}
-                                                {order.gst?.sgst > 0 && (
-                                                        <View style={[styles.totalRow, { paddingLeft: 10 }]}>
-                                                                <Text>SGST (9%):</Text>
-                                                                <Text>${order.gst.sgst.toFixed(2)}</Text>
-                                                        </View>
-                                                )}
-                                                {order.gst?.igst > 0 && (
-                                                        <View style={[styles.totalRow, { paddingLeft: 10 }]}>
-                                                                <Text>IGST (18%):</Text>
-                                                                <Text>${order.gst.igst.toFixed(2)}</Text>
-                                                        </View>
-                                                )}
-                                        </View>
-                                )}
-				{order.shippingCost > 0 && (
-					<View style={styles.totalRow}>
-						<Text>Shipping:</Text>
-						<Text>${order.shippingCost.toFixed(2)}</Text>
-					</View>
-				)}
-				{order.discount > 0 && (
-					<View style={styles.totalRow}>
-						<Text>Discount:</Text>
-						<Text>-${order.discount.toFixed(2)}</Text>
-					</View>
-				)}
-				<View style={[styles.totalRow, styles.grandTotal]}>
-					<Text>Total Amount:</Text>
-					<Text>${order.totalAmount.toFixed(2)}</Text>
-				</View>
+                               <View style={styles.totalRow}>
+                                       <Text>Subtotal:</Text>
+                                       <Text>₹{order.subtotal.toFixed(2)}</Text>
+                               </View>
+                               {order.tax > 0 && (
+                                       <View>
+                                               <View style={styles.totalRow}>
+                                                       <Text>GST (18%):</Text>
+                                                       <Text>₹{order.tax.toFixed(2)}</Text>
+                                               </View>
+                                               {order.gst?.cgst > 0 && (
+                                                       <View style={[styles.totalRow, { paddingLeft: 10 }]}>
+                                                               <Text>CGST (9%):</Text>
+                                                               <Text>₹{order.gst.cgst.toFixed(2)}</Text>
+                                                       </View>
+                                               )}
+                                               {order.gst?.sgst > 0 && (
+                                                       <View style={[styles.totalRow, { paddingLeft: 10 }]}>
+                                                               <Text>SGST (9%):</Text>
+                                                               <Text>₹{order.gst.sgst.toFixed(2)}</Text>
+                                                       </View>
+                                               )}
+                                               {order.gst?.igst > 0 && (
+                                                       <View style={[styles.totalRow, { paddingLeft: 10 }]}>
+                                                               <Text>IGST (18%):</Text>
+                                                               <Text>₹{order.gst.igst.toFixed(2)}</Text>
+                                                       </View>
+                                               )}
+                                       </View>
+                               )}
+                               {order.shippingCost > 0 && (
+                                       <View style={styles.totalRow}>
+                                               <Text>Shipping:</Text>
+                                               <Text>₹{order.shippingCost.toFixed(2)}</Text>
+                                       </View>
+                               )}
+                               {order.discount > 0 && (
+                                       <View style={styles.totalRow}>
+                                               <Text>Discount:</Text>
+                                               <Text>-₹{order.discount.toFixed(2)}</Text>
+                                       </View>
+                               )}
+                               <View style={[styles.totalRow, styles.grandTotal]}>
+                                       <Text>Total Amount:</Text>
+                                       <Text>₹{order.totalAmount.toFixed(2)}</Text>
+                               </View>
 			</View>
 
 			{/* Footer */}


### PR DESCRIPTION
## Summary
- replace dollar signs with rupee symbol across invoices, order views, and account pages
- swap to IndianRupee icon for admin revenue stats
- adjust labels and sample data to reference ₹

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b197c6d514832ea2cd8a05c236ca93