### PR TITLE
fix: allow COD checkout without Razorpay

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -227,11 +227,11 @@ export default function CheckoutPage() {
 	}, [couponCode, applyCoupon, checkoutType]);
 
 	// Handle payment
-	const handlePayment = useCallback(async () => {
-		if (!isRazorpayLoaded) {
-			toast.error("Payment system is loading. Please wait.");
-			return;
-		}
+        const handlePayment = useCallback(async () => {
+                if (paymentMethod === "razorpay" && !isRazorpayLoaded) {
+                        toast.error("Payment system is loading. Please wait.");
+                        return;
+                }
 
 		if (!getSelectedAddress()) {
 			toast.error("Please select a delivery address");
@@ -251,14 +251,15 @@ export default function CheckoutPage() {
 			console.error("Payment error:", error);
 			toast.error(error.message || "Payment failed. Please try again.");
 		}
-	}, [
-		isRazorpayLoaded,
-		processPayment,
-		user,
-		checkoutType,
-		clearCart,
-		getSelectedAddress,
-	]);
+        }, [
+                isRazorpayLoaded,
+                processPayment,
+                user,
+                checkoutType,
+                clearCart,
+                getSelectedAddress,
+                paymentMethod,
+        ]);
 
 	// Address Step Component
 	const AddressStep = useMemo(

--- a/app/(buyers)/order-success/page.jsx
+++ b/app/(buyers)/order-success/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,14 +9,33 @@ import { Badge } from "@/components/ui/badge";
 import { CheckCircle, Package, Truck, Home, Download, Eye } from "lucide-react";
 import Link from "next/link";
 import { InvoicePopup } from "@/components/AdminPanel/Popups/InvoicePopup.jsx";
-import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 
 export default function OrderSuccessPage() {
 	const router = useRouter();
 	const searchParams = useSearchParams();
         const [orderDetails, setOrderDetails] = useState(null);
         const [invoiceOpen, setInvoiceOpen] = useState(false);
-        const { downloadInvoice } = useAdminOrderStore();
+
+        const downloadInvoice = useCallback(async (id, orderNumber) => {
+                try {
+                        const response = await fetch(`/api/orders/${id}/invoice`);
+                        if (response.ok) {
+                                const blob = await response.blob();
+                                const url = window.URL.createObjectURL(blob);
+                                const a = document.createElement("a");
+                                a.href = url;
+                                a.download = `invoice-${orderNumber}.pdf`;
+                                document.body.appendChild(a);
+                                a.click();
+                                window.URL.revokeObjectURL(url);
+                                document.body.removeChild(a);
+                                return { success: true };
+                        }
+                        return { success: false, message: "Failed to download invoice" };
+                } catch (error) {
+                        return { success: false, message: "Failed to download invoice" };
+                }
+        }, []);
 
 	const orderId = searchParams.get("orderId");
 	const orderNumber = searchParams.get("orderNumber");
@@ -27,7 +46,7 @@ export default function OrderSuccessPage() {
                                 router.push("/");
                                 return;
                         }
-                        const res = await fetch(`/api/admin/orders/${orderId}`);
+                        const res = await fetch(`/api/orders/${orderId}`);
                         const data = await res.json();
                         if (data.success) {
                                 setOrderDetails(data.order);
@@ -175,6 +194,7 @@ export default function OrderSuccessPage() {
                                         open={invoiceOpen}
                                         onOpenChange={setInvoiceOpen}
                                         order={orderDetails}
+                                        downloadInvoice={downloadInvoice}
                                 />
                         </div>
                 </div>

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -9,8 +9,9 @@ import { Download, Printer } from "lucide-react";
 import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 import { toast } from "sonner";
 
-export function InvoicePopup({ open, onOpenChange, order }) {
-	const { downloadInvoice } = useAdminOrderStore();
+export function InvoicePopup({ open, onOpenChange, order, downloadInvoice: downloadInvoiceProp }) {
+        const { downloadInvoice: adminDownloadInvoice } = useAdminOrderStore();
+        const downloadInvoice = downloadInvoiceProp || adminDownloadInvoice;
 
 	if (!order) return null;
 


### PR DESCRIPTION
## Summary
- skip Razorpay script check for cash on delivery so order confirmation and invoice actions appear
- load order details from customer endpoint after COD checkout and enable invoice download
