### PR TITLE
fix: allow COD checkout without Razorpay

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -227,11 +227,11 @@ export default function CheckoutPage() {
 	}, [couponCode, applyCoupon, checkoutType]);
 
 	// Handle payment
-	const handlePayment = useCallback(async () => {
-		if (!isRazorpayLoaded) {
-			toast.error("Payment system is loading. Please wait.");
-			return;
-		}
+        const handlePayment = useCallback(async () => {
+                if (paymentMethod === "razorpay" && !isRazorpayLoaded) {
+                        toast.error("Payment system is loading. Please wait.");
+                        return;
+                }
 
 		if (!getSelectedAddress()) {
 			toast.error("Please select a delivery address");
@@ -251,14 +251,15 @@ export default function CheckoutPage() {
 			console.error("Payment error:", error);
 			toast.error(error.message || "Payment failed. Please try again.");
 		}
-	}, [
-		isRazorpayLoaded,
-		processPayment,
-		user,
-		checkoutType,
-		clearCart,
-		getSelectedAddress,
-	]);
+        }, [
+                isRazorpayLoaded,
+                processPayment,
+                user,
+                checkoutType,
+                clearCart,
+                getSelectedAddress,
+                paymentMethod,
+        ]);
 
 	// Address Step Component
 	const AddressStep = useMemo(

--- a/app/api/orders/[id]/invoice/route.js
+++ b/app/api/orders/[id]/invoice/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/lib/dbConnect.js";
+import Order from "@/model/Order.js";
+import { generateInvoicePDF } from "@/lib/generateInvoicePDF.js";
+
+export async function GET(request, { params }) {
+        try {
+                await dbConnect();
+
+                const order = await Order.findById(params.id)
+                        .populate("userId", "firstName lastName email mobile")
+                        .populate("products.productId", "name images price")
+                        .populate(
+                                "couponApplied.couponId",
+                                "code discountType discountValue"
+                        );
+
+                if (!order) {
+                        return NextResponse.json(
+                                { success: false, message: "Order not found" },
+                                { status: 404 }
+                        );
+                }
+
+                const pdfBuffer = await generateInvoicePDF(order);
+
+                return new NextResponse(pdfBuffer, {
+                        headers: {
+                                "Content-Type": "application/pdf",
+                                "Content-Disposition": `attachment; filename="invoice-${order.orderNumber}.pdf"`,
+                        },
+                });
+        } catch (error) {
+                console.error("Error generating invoice:", error);
+                return NextResponse.json(
+                        { success: false, message: "Failed to generate invoice" },
+                        { status: 500 }
+                );
+        }
+}

--- a/app/api/orders/[id]/route.js
+++ b/app/api/orders/[id]/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/lib/dbConnect.js";
+import Order from "@/model/Order.js";
+
+export async function GET(request, { params }) {
+        try {
+                await dbConnect();
+
+                const order = await Order.findById(params.id)
+                        .populate("userId", "firstName lastName email mobile")
+                        .populate("products.productId", "name images price")
+                        .populate(
+                                "couponApplied.couponId",
+                                "code discountType discountValue"
+                        );
+
+                if (!order) {
+                        return NextResponse.json(
+                                { success: false, message: "Order not found" },
+                                { status: 404 }
+                        );
+                }
+
+                return NextResponse.json({ success: true, order });
+        } catch (error) {
+                console.error("Error fetching order:", error);
+                return NextResponse.json(
+                        { success: false, message: "Failed to fetch order" },
+                        { status: 500 }
+                );
+        }
+}

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -9,8 +9,9 @@ import { Download, Printer } from "lucide-react";
 import { useAdminOrderStore } from "@/store/adminOrderStore.js";
 import { toast } from "sonner";
 
-export function InvoicePopup({ open, onOpenChange, order }) {
-	const { downloadInvoice } = useAdminOrderStore();
+export function InvoicePopup({ open, onOpenChange, order, downloadInvoice: downloadInvoiceProp }) {
+        const { downloadInvoice: adminDownloadInvoice } = useAdminOrderStore();
+        const downloadInvoice = downloadInvoiceProp || adminDownloadInvoice;
 
 	if (!order) return null;
 


### PR DESCRIPTION
## Summary
- add customer order detail and invoice endpoints
- guard order success fetch from non-JSON responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1980350a0832ea98daae5fe49ef99