### PR TITLE
Show order confirmation and add invoice download

### DIFF
--- a/app/(buyers)/order-success/page.jsx
+++ b/app/(buyers)/order-success/page.jsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { CheckCircle, Package, Truck, Home, Download, Eye } from "lucide-react";
 import Link from "next/link";
 import { InvoicePopup } from "@/components/AdminPanel/Popups/InvoicePopup.jsx";
+import { generateInvoicePDF } from "@/lib/generateInvoicePDF.js";
 
 export default function OrderSuccessPage() {
 	const router = useRouter();
@@ -18,24 +19,20 @@ export default function OrderSuccessPage() {
 
         const downloadInvoice = useCallback(async (id, orderNumber) => {
                 try {
-                        const response = await fetch(`/api/orders/${id}/invoice`);
-                        if (response.ok) {
-                                const blob = await response.blob();
-                                const url = window.URL.createObjectURL(blob);
-                                const a = document.createElement("a");
-                                a.href = url;
-                                a.download = `invoice-${orderNumber}.pdf`;
-                                document.body.appendChild(a);
-                                a.click();
-                                window.URL.revokeObjectURL(url);
-                                document.body.removeChild(a);
-                                return { success: true };
-                        }
-                        return { success: false, message: "Failed to download invoice" };
+                        const blob = await generateInvoicePDF(orderDetails);
+                        const url = window.URL.createObjectURL(blob);
+                        const a = document.createElement("a");
+                        a.href = url;
+                        a.download = `invoice-${orderNumber}.pdf`;
+                        document.body.appendChild(a);
+                        a.click();
+                        window.URL.revokeObjectURL(url);
+                        document.body.removeChild(a);
+                        return { success: true };
                 } catch (error) {
-                        return { success: false, message: "Failed to download invoice" };
+                        return { success: false, message: "Failed to generate invoice" };
                 }
-        }, []);
+        }, [orderDetails]);
 
 	const orderId = searchParams.get("orderId");
 	const orderNumber = searchParams.get("orderNumber");

--- a/components/BuyerPanel/account/OrderDetailsPopup.jsx
+++ b/components/BuyerPanel/account/OrderDetailsPopup.jsx
@@ -3,8 +3,11 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Package, MapPin, CreditCard, Calendar } from "lucide-react";
+import { Package, MapPin, CreditCard, Calendar, Download } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { generateInvoicePDF } from "@/lib/generateInvoicePDF.js";
 
 export function OrderDetailsPopup({ open, onOpenChange, order }) {
         if (!order) return null;
@@ -32,13 +35,39 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                 return colors[status] || "bg-gray-100 text-gray-800";
         };
 
+        const downloadInvoice = async () => {
+                try {
+                        const blob = await generateInvoicePDF(order);
+                        const url = window.URL.createObjectURL(blob);
+                        const a = document.createElement("a");
+                        a.href = url;
+                        a.download = `invoice-${order.orderNumber}.pdf`;
+                        document.body.appendChild(a);
+                        a.click();
+                        window.URL.revokeObjectURL(url);
+                        document.body.removeChild(a);
+                        toast.success("Invoice downloaded");
+                } catch (error) {
+                        toast.error("Failed to generate invoice");
+                }
+        };
+
         return (
                 <Dialog open={open} onOpenChange={onOpenChange}>
                         <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
                                 <DialogHeader>
-                                        <DialogTitle className="text-xl font-bold">
-                                                Order Details - {order.orderNumber}
-                                        </DialogTitle>
+                                        <div className="flex items-center justify-between gap-4">
+                                                <DialogTitle className="text-xl font-bold">
+                                                        Order Details - {order.orderNumber}
+                                                </DialogTitle>
+                                                <Button
+                                                        variant="outline"
+                                                        size="sm"
+                                                        onClick={downloadInvoice}
+                                                >
+                                                        <Download className="w-4 h-4 mr-2" /> Invoice
+                                                </Button>
+                                        </div>
                                 </DialogHeader>
 
                                 <div className="space-y-6 mt-6">

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -253,9 +253,14 @@ const InvoiceDocument = ({ order }) => (
 );
 
 export const generateInvoicePDF = async (order) => {
-	const doc = <InvoiceDocument order={order} />;
-	const pdfBuffer = await pdf(doc).toBuffer();
-	return pdfBuffer;
+        const doc = <InvoiceDocument order={order} />;
+        // On the server we generate a Buffer, in the browser we generate a Blob
+        if (typeof window === "undefined") {
+                const pdfBuffer = await pdf(doc).toBuffer();
+                return pdfBuffer;
+        }
+        const pdfBlob = await pdf(doc).toBlob();
+        return pdfBlob;
 };
 
 export default InvoiceDocument;

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -548,10 +548,12 @@ export const useCheckoutStore = create(
 											// Reset checkout
 											get().resetCheckout();
 
-											toast.success("Payment successful! Order placed.");
+                                                                                        toast.success("Order placed successfully!");
 
-											// Redirect to success page
-											window.location.href = `/order-success?orderId=${verificationResult.orderId}&orderNumber=${verificationResult.orderNumber}`;
+                                                                                        // Show confirmation then redirect to orders page
+                                                                                        setTimeout(() => {
+                                                                                                window.location.href = "/account/orders";
+                                                                                        }, 2000);
 										} else {
 											toast.error("Payment verification failed");
 										}
@@ -605,10 +607,12 @@ export const useCheckoutStore = create(
 								// Reset checkout
 								get().resetCheckout();
 
-								toast.success("Order placed successfully!");
+                                                                toast.success("Order placed successfully!");
 
-								// Redirect to success page
-								window.location.href = `/order-success?orderId=${result.orderId}&orderNumber=${result.orderNumber}`;
+                                                                // Show confirmation then redirect to orders page
+                                                                setTimeout(() => {
+                                                                        window.location.href = "/account/orders";
+                                                                }, 2000);
 
 								return { success: true, paymentMethod: "cod" };
 							} else {


### PR DESCRIPTION
## Summary
- Redirect users to their order history after successful Razorpay or COD checkout with a brief confirmation popup
- Generate invoice PDFs on the client and expose download buttons on order success and account order details popups

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sweetalert2)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a2c31594832eb715ac0f7b657588