### PR TITLE
Support Google Drive folder image links in bulk upload

### DIFF
--- a/app/api/admin/product/bulkUploadProduct/route.js
+++ b/app/api/admin/product/bulkUploadProduct/route.js
@@ -3,6 +3,7 @@
 import { dbConnect } from "@/lib/dbConnect";
 import Product from "@/model/Product";
 import Category from "@/model/Category";
+import { getGoogleDriveFolderImageUrls } from "@/lib/utils";
 
 export async function POST(request) {
 	await dbConnect();
@@ -103,7 +104,20 @@ export async function POST(request) {
 
                                 const finalCategory = productData.category || category;
 
-                                const featureImageUrl = featureImage || mainImageLink || "";
+                                let images = Array.isArray(productData.images)
+                                        ? productData.images
+                                        : [];
+                                if (!images.length && productData.imageFolder) {
+                                        images = await getGoogleDriveFolderImageUrls(
+                                                productData.imageFolder
+                                        );
+                                }
+
+                                const featureImageUrl =
+                                        featureImage ||
+                                        mainImageLink ||
+                                        images[0] ||
+                                        "";
 
                                 const parsedLength =
                                         length !== undefined && length !== ""
@@ -149,7 +163,7 @@ export async function POST(request) {
                                         material,
                                         brand,
                                         size,
-                                        images: featureImageUrl ? [featureImageUrl] : [],
+                                        images,
                                         published:
                                                 productData.published !== undefined ? productData.published : true,
                                         stocks: productData.stocks ? Number.parseInt(productData.stocks) : 0,

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -105,6 +105,12 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                                 mainImageLink: getDirectGoogleDriveImageUrl(
                                         row["Main Image Link"]
                                 ),
+                                imageFolder:
+                                        row["Images URL Link (7 images)"] ||
+                                        row["Images Folder"] ||
+                                        row["Image Folder"] ||
+                                        row["Image Folder Link"] ||
+                                        row["Google Drive Folder Link"],
                                 length: row["Length (mm)"],
                                 width: row["Width (mm)"],
                                 height: row["height (mm)"],
@@ -164,7 +170,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "Price",
                         "MRP",
                         "Feature Image",
-                        "Main Image Link",
                         "Images URL Link (7 images)",
                         "Length (mm)",
                         "Width (mm)",
@@ -185,8 +190,7 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "100",
                         "120",
                         "https://example.com/image.jpg",
-                        "https://drive.google.com/sample",
-                        "",
+                        "https://drive.google.com/drive/folders/sample",
                         "10",
                         "5",
                         "3",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,3 +26,34 @@ export function getDirectGoogleDriveImageUrl(url) {
 
   return url;
 }
+
+// Fetches all image files inside a shared Google Drive folder and
+// returns direct googleusercontent links for each image.
+// Requires a public folder and a valid GOOGLE_DRIVE_API_KEY env variable.
+export async function getGoogleDriveFolderImageUrls(folderUrl) {
+  if (!folderUrl) return [];
+
+  try {
+    const match = folderUrl.match(/(?:folders\/|id=)([a-zA-Z0-9_-]+)/);
+    const folderId = match && match[1];
+    const apiKey = process.env.GOOGLE_DRIVE_API_KEY;
+
+    if (!folderId || !apiKey) return [];
+
+    const query = encodeURIComponent(
+      `'${folderId}' in parents and mimeType contains 'image/' and trashed=false`
+    );
+    const fields = encodeURIComponent("files(id)");
+    const url = `https://www.googleapis.com/drive/v3/files?q=${query}&fields=${fields}&key=${apiKey}`;
+
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (
+      data.files?.map((file) => `https://lh3.googleusercontent.com/d/${file.id}`) || []
+    );
+  } catch (e) {
+    console.error("Failed to fetch images from Drive folder", e);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- parse "Images URL Link (7 images)" column during bulk product CSV upload
- update CSV template so the folder link column appears in column J with a sample Drive folder URL
- convert Drive folder contents into direct `googleusercontent` links when saving images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e50a51b4832e96f026bf51a54b9b