### PR TITLE
fix: correct category and image handling in bulk upload

### DIFF
--- a/app/api/admin/product/bulkUploadProduct/route.js
+++ b/app/api/admin/product/bulkUploadProduct/route.js
@@ -75,13 +75,6 @@ export async function POST(request) {
                                         let existingCategory = await Category.findOne({ slug: categorySlug });
 
                                         if (existingCategory) {
-                                                // Track duplicate category product
-                                                results.duplicates = results.duplicates || [];
-                                                results.duplicates.push({
-                                                        title,
-                                                        category: existingCategory.name,
-                                                });
-
                                                 if (subCategory) {
                                                         await Category.updateOne(
                                                                 { _id: existingCategory._id },
@@ -104,10 +97,8 @@ export async function POST(request) {
 
                                 const finalCategory = productData.category || category;
 
-                                let images = Array.isArray(productData.images)
-                                        ? productData.images
-                                        : [];
-                                if (!images.length && productData.imageFolder) {
+                                let images = [];
+                                if (productData.imageFolder) {
                                         images = await getGoogleDriveFolderImageUrls(
                                                 productData.imageFolder
                                         );
@@ -119,12 +110,8 @@ export async function POST(request) {
                                         images[0] ||
                                         "";
 
-                                if (featureImageUrl) {
-                                        images = [
-                                                featureImageUrl,
-                                                ...images.filter((img) => img !== featureImageUrl),
-                                        ];
-                                }
+                                const finalMainImageLink =
+                                        mainImageLink || featureImageUrl;
 
                                 const parsedLength =
                                         length !== undefined && length !== ""
@@ -152,7 +139,7 @@ export async function POST(request) {
                                         price: parsedPrice,
                                         mrp: parsedMrp,
                                         featureImage: featureImageUrl,
-                                        mainImageLink,
+                                        mainImageLink: finalMainImageLink,
                                         hsnCode,
                                         length: Number.isNaN(parsedLength)
                                                 ? undefined

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -91,35 +91,53 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                 reader.onload = (event) => {
                         const text = event.target.result;
                         const rows = parseCSV(text);
-                        const mapped = rows.map((row) => ({
-                                title: row["Product Name"],
-                                description: row["Description"],
-                                category: row["Product Category"],
-                                subCategory: row["Sub Category"] || row["Sub-Category"],
-                                hsnCode: row["HSN Code"],
-                                price: row["Price"],
-                                mrp: row["MRP"],
-                                featureImage: getDirectGoogleDriveImageUrl(
-                                        row["Feature Image"]
-                                ),
-                                mainImageLink: getDirectGoogleDriveImageUrl(
-                                        row["Main Image Link"]
-                                ),
-                                imageFolder:
-                                        row["Images URL Link (7 images)"] ||
-                                        row["Images Folder"] ||
-                                        row["Image Folder"] ||
-                                        row["Image Folder Link"] ||
-                                        row["Google Drive Folder Link"],
-                                length: row["Length (mm)"],
-                                width: row["Width (mm)"],
-                                height: row["height (mm)"],
-                                weight: row["Weight (gms)"],
-                                colour: row["Colour"],
-                                material: row["Material used / Made Of"],
-                                brand: row["brand"],
-                                size: row["size"],
-                        }));
+                        const mapped = rows.map((row) => {
+                                const singleImage =
+                                        row["Main Image Link"] ||
+                                        row["Feature Image"] ||
+                                        row["Image"] ||
+                                        row["Image Link"];
+
+                                return {
+                                        title: row["Product Name"] || row["Title"] || row["Name"],
+                                        description: row["Description"] || row["Desc"],
+                                        category:
+                                                row["Product Category"] ||
+                                                row["Category"],
+                                        subCategory:
+                                                row["Sub Category"] ||
+                                                row["Sub-Category"] ||
+                                                row["SubCategory"],
+                                        hsnCode: row["HSN Code"] || row["HSN"],
+                                        price: row["Price"],
+                                        mrp: row["MRP"] || row["Mrp"],
+                                        featureImage:
+                                                getDirectGoogleDriveImageUrl(singleImage),
+                                        mainImageLink:
+                                                getDirectGoogleDriveImageUrl(singleImage),
+                                        imageFolder:
+                                                row["Images URL Link (7 images)"] ||
+                                                row["Images Folder"] ||
+                                                row["Image Folder"] ||
+                                                row["Image Folder Link"] ||
+                                                row["Google Drive Folder Link"],
+                                        length: row["Length (mm)"] || row["Length"],
+                                        width: row["Width (mm)"] || row["Width"],
+                                        height:
+                                                row["height (mm)"] ||
+                                                row["Height (mm)"] ||
+                                                row["Height"],
+                                        weight:
+                                                row["Weight (gms)"] ||
+                                                row["Weight"],
+                                        colour: row["Colour"] || row["Color"],
+                                        material:
+                                                row["Material used / Made Of"] ||
+                                                row["Material"],
+                                        brand: row["brand"] || row["Brand"],
+                                        size: row["size"] || row["Size"],
+                                };
+                        });
 
                         const requiredFields = ["title", "price", "mrp", "category"];
                         const invalid = [];
@@ -168,7 +186,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "Description",
                         "Price",
                         "MRP",
-                        "Feature Image",
                         "Main Image Link",
                         "Images URL Link (7 images)",
                         "Length (mm)",
@@ -188,7 +205,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "Sample description",
                         "100",
                         "120",
-                        "https://example.com/feature-image.jpg",
                         "https://example.com/main-image.jpg",
                         "https://drive.google.com/drive/folders/sample",
                         "10",


### PR DESCRIPTION
## Summary
- allow bulk upload to read category and other fields from varied headers
- support single-image column for both feature and main image
- simplify image folder logic and ensure main image link is always populated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f1f9041c832ebf2389531c9acc2f