### PR TITLE
fix: correct category and image handling in bulk upload

### DIFF
--- a/app/api/admin/product/bulkUploadProduct/route.js
+++ b/app/api/admin/product/bulkUploadProduct/route.js
@@ -75,13 +75,6 @@ export async function POST(request) {
                                         let existingCategory = await Category.findOne({ slug: categorySlug });
 
                                         if (existingCategory) {
-                                                // Track duplicate category product
-                                                results.duplicates = results.duplicates || [];
-                                                results.duplicates.push({
-                                                        title,
-                                                        category: existingCategory.name,
-                                                });
-
                                                 if (subCategory) {
                                                         await Category.updateOne(
                                                                 { _id: existingCategory._id },
@@ -104,10 +97,8 @@ export async function POST(request) {
 
                                 const finalCategory = productData.category || category;
 
-                                let images = Array.isArray(productData.images)
-                                        ? productData.images
-                                        : [];
-                                if (!images.length && productData.imageFolder) {
+                                let images = [];
+                                if (productData.imageFolder) {
                                         images = await getGoogleDriveFolderImageUrls(
                                                 productData.imageFolder
                                         );
@@ -119,12 +110,8 @@ export async function POST(request) {
                                         images[0] ||
                                         "";
 
-                                if (featureImageUrl) {
-                                        images = [
-                                                featureImageUrl,
-                                                ...images.filter((img) => img !== featureImageUrl),
-                                        ];
-                                }
+                                const finalMainImageLink =
+                                        mainImageLink || featureImageUrl;
 
                                 const parsedLength =
                                         length !== undefined && length !== ""
@@ -152,7 +139,7 @@ export async function POST(request) {
                                         price: parsedPrice,
                                         mrp: parsedMrp,
                                         featureImage: featureImageUrl,
-                                        mainImageLink,
+                                        mainImageLink: finalMainImageLink,
                                         hsnCode,
                                         length: Number.isNaN(parsedLength)
                                                 ? undefined

--- a/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
+++ b/components/AdminPanel/Popups/BulkProductUploadPopup.jsx
@@ -91,35 +91,53 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                 reader.onload = (event) => {
                         const text = event.target.result;
                         const rows = parseCSV(text);
-                        const mapped = rows.map((row) => ({
-                                title: row["Product Name"],
-                                description: row["Description"],
-                                category: row["Product Category"],
-                                subCategory: row["Sub Category"] || row["Sub-Category"],
-                                hsnCode: row["HSN Code"],
-                                price: row["Price"],
-                                mrp: row["MRP"],
-                                featureImage: getDirectGoogleDriveImageUrl(
-                                        row["Feature Image"]
-                                ),
-                                mainImageLink: getDirectGoogleDriveImageUrl(
-                                        row["Main Image Link"]
-                                ),
-                                imageFolder:
-                                        row["Images URL Link (7 images)"] ||
-                                        row["Images Folder"] ||
-                                        row["Image Folder"] ||
-                                        row["Image Folder Link"] ||
-                                        row["Google Drive Folder Link"],
-                                length: row["Length (mm)"],
-                                width: row["Width (mm)"],
-                                height: row["height (mm)"],
-                                weight: row["Weight (gms)"],
-                                colour: row["Colour"],
-                                material: row["Material used / Made Of"],
-                                brand: row["brand"],
-                                size: row["size"],
-                        }));
+                        const mapped = rows.map((row) => {
+                                const singleImage =
+                                        row["Main Image Link"] ||
+                                        row["Feature Image"] ||
+                                        row["Image"] ||
+                                        row["Image Link"];
+
+                                return {
+                                        title: row["Product Name"] || row["Title"] || row["Name"],
+                                        description: row["Description"] || row["Desc"],
+                                        category:
+                                                row["Product Category"] ||
+                                                row["Category"],
+                                        subCategory:
+                                                row["Sub Category"] ||
+                                                row["Sub-Category"] ||
+                                                row["SubCategory"],
+                                        hsnCode: row["HSN Code"] || row["HSN"],
+                                        price: row["Price"],
+                                        mrp: row["MRP"] || row["Mrp"],
+                                        featureImage:
+                                                getDirectGoogleDriveImageUrl(singleImage),
+                                        mainImageLink:
+                                                getDirectGoogleDriveImageUrl(singleImage),
+                                        imageFolder:
+                                                row["Images URL Link (7 images)"] ||
+                                                row["Images Folder"] ||
+                                                row["Image Folder"] ||
+                                                row["Image Folder Link"] ||
+                                                row["Google Drive Folder Link"],
+                                        length: row["Length (mm)"] || row["Length"],
+                                        width: row["Width (mm)"] || row["Width"],
+                                        height:
+                                                row["height (mm)"] ||
+                                                row["Height (mm)"] ||
+                                                row["Height"],
+                                        weight:
+                                                row["Weight (gms)"] ||
+                                                row["Weight"],
+                                        colour: row["Colour"] || row["Color"],
+                                        material:
+                                                row["Material used / Made Of"] ||
+                                                row["Material"],
+                                        brand: row["brand"] || row["Brand"],
+                                        size: row["size"] || row["Size"],
+                                };
+                        });
 
                         const requiredFields = ["title", "price", "mrp", "category"];
                         const invalid = [];
@@ -168,7 +186,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "Description",
                         "Price",
                         "MRP",
-                        "Feature Image",
                         "Main Image Link",
                         "Images URL Link (7 images)",
                         "Length (mm)",
@@ -188,7 +205,6 @@ export function BulkUploadPopup({ open, onOpenChange }) {
                         "Sample description",
                         "100",
                         "120",
-                        "https://example.com/feature-image.jpg",
                         "https://example.com/main-image.jpg",
                         "https://drive.google.com/drive/folders/sample",
                         "10",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,31 +27,51 @@ export function getDirectGoogleDriveImageUrl(url) {
   return url;
 }
 
-// Fetches all image files inside a shared Google Drive folder and
-// returns direct googleusercontent links for each image.
-// Requires a public folder and a valid GOOGLE_DRIVE_API_KEY env variable.
+// Fetches all image files inside a shared Google Drive folder and returns
+// direct googleusercontent links for each image. Uses the Drive API when an
+// API key is available and falls back to scraping the public embedded folder
+// view when it's not.
 export async function getGoogleDriveFolderImageUrls(folderUrl) {
   if (!folderUrl) return [];
 
   try {
     const match = folderUrl.match(/(?:folders\/|id=)([a-zA-Z0-9_-]+)/);
     const folderId = match && match[1];
+    if (!folderId) return [];
+
     const apiKey = process.env.GOOGLE_DRIVE_API_KEY;
 
-    if (!folderId || !apiKey) return [];
+    // Prefer the official Google Drive API when a key is present
+    if (apiKey) {
+      const query = encodeURIComponent(
+        `'${folderId}' in parents and mimeType contains 'image/' and trashed=false`
+      );
+      const fields = encodeURIComponent("files(id)");
+      const url = `https://www.googleapis.com/drive/v3/files?q=${query}&fields=${fields}&key=${apiKey}`;
 
-    const query = encodeURIComponent(
-      `'${folderId}' in parents and mimeType contains 'image/' and trashed=false`
-    );
-    const fields = encodeURIComponent("files(id)");
-    const url = `https://www.googleapis.com/drive/v3/files?q=${query}&fields=${fields}&key=${apiKey}`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const links =
+          data.files?.map((file) => `https://lh3.googleusercontent.com/d/${file.id}`) || [];
+        if (links.length) return links;
+      }
+    }
 
-    const res = await fetch(url);
-    if (!res.ok) return [];
-    const data = await res.json();
-    return (
-      data.files?.map((file) => `https://lh3.googleusercontent.com/d/${file.id}`) || []
-    );
+    // Fallback: use the public embedded folder view and scrape image sources
+    const embeddedUrl = `https://drive.google.com/embeddedfolderview?id=${folderId}#grid`;
+    const html = await fetch(embeddedUrl).then((r) => (r.ok ? r.text() : ""));
+    if (!html) return [];
+
+    // Extract each file's id from the markup and convert to a direct image link
+    const idRegex = /data-id="([a-zA-Z0-9_-]+)"/g;
+    const links = [];
+    let m;
+    while ((m = idRegex.exec(html)) !== null) {
+      links.push(`https://lh3.googleusercontent.com/d/${m[1]}`);
+    }
+
+    return links;
   } catch (e) {
     console.error("Failed to fetch images from Drive folder", e);
     return [];


### PR DESCRIPTION
## Summary
- allow bulk upload to read category and other fields from varied headers
- support single-image column for both feature and main image
- simplify image folder logic and ensure main image link is always populated
- populate images array from Google Drive folders even without API key
