### PR TITLE
Proxy Google Drive folder image requests

### DIFF
--- a/app/api/google-drive/folder-images/route.js
+++ b/app/api/google-drive/folder-images/route.js
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+// Server-side helper to fetch image links from a Google Drive folder
+async function fetchFolderImages(folderId) {
+  const apiKey = process.env.GOOGLE_DRIVE_API_KEY;
+
+  // Use official API when a key is available
+  if (apiKey) {
+    const query = encodeURIComponent(
+      `'${folderId}' in parents and mimeType contains 'image/' and trashed=false`
+    );
+    const fields = encodeURIComponent("files(id)");
+    const url = `https://www.googleapis.com/drive/v3/files?q=${query}&fields=${fields}&key=${apiKey}`;
+    const res = await fetch(url);
+    if (res.ok) {
+      const data = await res.json();
+      const links =
+        data.files?.map((file) => `https://lh3.googleusercontent.com/d/${file.id}`) || [];
+      if (links.length) return links;
+    }
+  }
+
+  // Fallback: scrape the public embedded folder view
+  const embeddedUrl = `https://drive.google.com/embeddedfolderview?id=${folderId}#grid`;
+  const html = await fetch(embeddedUrl, {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+    },
+  }).then((r) => (r.ok ? r.text() : ""));
+  if (!html) return [];
+
+  // First try to scrape data-id attributes rendered in the markup
+  const idRegex = /data-id=['"]([^'"]+)['"]/g;
+  const ids = new Set();
+  let m;
+  while ((m = idRegex.exec(html)) !== null) {
+    ids.add(m[1]);
+  }
+
+  // Some folder views lazy-load items via JSON in <script> tags instead of
+  // rendering data-id attributes. Fall back to pulling any "id" fields from
+  // inline JSON blobs if we didn't get any matches above.
+  if (!ids.size) {
+    const jsonIdRegex = /"id":"([a-zA-Z0-9_-]{10,})"/g;
+    while ((m = jsonIdRegex.exec(html)) !== null) {
+      if (m[1] !== folderId) ids.add(m[1]);
+    }
+  }
+
+  return Array.from(ids).map((id) => `https://lh3.googleusercontent.com/d/${id}`);
+}
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const folderId = searchParams.get("id");
+  if (!folderId) {
+    return NextResponse.json({ links: [] }, { status: 400 });
+  }
+  try {
+    const links = await fetchFolderImages(folderId);
+    return NextResponse.json({ links });
+  } catch (e) {
+    return NextResponse.json({ links: [], error: e.message }, { status: 500 });
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,6 +38,15 @@ export async function getGoogleDriveFolderImageUrls(folderUrl) {
     const match = folderUrl.match(/(?:folders\/|id=)([a-zA-Z0-9_-]+)/);
     const folderId = match && match[1];
     if (!folderId) return [];
+    // On the client we proxy the request through our API route to avoid CORS
+    if (typeof window !== "undefined") {
+      const res = await fetch(`/api/google-drive/folder-images?id=${folderId}`);
+      if (res.ok) {
+        const data = await res.json();
+        return data.links || [];
+      }
+      return [];
+    }
 
     const apiKey = process.env.GOOGLE_DRIVE_API_KEY;
 
@@ -60,18 +69,29 @@ export async function getGoogleDriveFolderImageUrls(folderUrl) {
 
     // Fallback: use the public embedded folder view and scrape image sources
     const embeddedUrl = `https://drive.google.com/embeddedfolderview?id=${folderId}#grid`;
-    const html = await fetch(embeddedUrl).then((r) => (r.ok ? r.text() : ""));
+    const html = await fetch(embeddedUrl, {
+      headers: {
+        "User-Agent": "Mozilla/5.0",
+      },
+    }).then((r) => (r.ok ? r.text() : ""));
     if (!html) return [];
 
-    // Extract each file's id from the markup and convert to a direct image link
-    const idRegex = /data-id="([a-zA-Z0-9_-]+)"/g;
-    const links = [];
+    // Extract file IDs either from data-id attributes or inline JSON.
+    const idRegex = /data-id=['"]([^'"]+)['"]/g;
+    const ids = new Set();
     let m;
     while ((m = idRegex.exec(html)) !== null) {
-      links.push(`https://lh3.googleusercontent.com/d/${m[1]}`);
+      ids.add(m[1]);
     }
 
-    return links;
+    if (!ids.size) {
+      const jsonIdRegex = /"id":"([a-zA-Z0-9_-]{10,})"/g;
+      while ((m = jsonIdRegex.exec(html)) !== null) {
+        if (m[1] !== folderId) ids.add(m[1]);
+      }
+    }
+
+    return Array.from(ids).map((id) => `https://lh3.googleusercontent.com/d/${id}`);
   } catch (e) {
     console.error("Failed to fetch images from Drive folder", e);
     return [];


### PR DESCRIPTION
## Summary
- Add API route to retrieve Google Drive folder images server-side
- Proxy client requests through new endpoint in `getGoogleDriveFolderImageUrls`
- Make folder image scraping more robust by mimicking browser requests and using a flexible ID regex
- Improve fallback scraping by also parsing file IDs from inline JSON when `data-id` attributes aren't rendered
