### PR TITLE
Increase admin product image limit to 10

### DIFF
--- a/components/AdminPanel/ImageUpload.jsx
+++ b/components/AdminPanel/ImageUpload.jsx
@@ -5,19 +5,19 @@ import { Label } from "@/components/ui/label";
 import { Upload, X, ImageIcon } from "lucide-react";
 
 export function ImageUpload({
-	images = [], // Array of base64 strings
-	onImagesChange,
-	label = "Product Images",
-	required = true,
+        images = [], // Array of base64 strings
+        onImagesChange,
+        label = "Product Images",
+        required = true,
+        maxImages = 5,
 }) {
 	const [isDragging, setIsDragging] = useState(false);
 	const [errors, setErrors] = useState([]);
 	const [imageMetadata, setImageMetadata] = useState([]); // Store metadata separately
 	const fileInputRef = useRef(null);
 
-	const MAX_IMAGES = 5;
-	const MAX_SIZE = 5 * 1024 * 1024; // 5MB
-	const VALID_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
+        const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+        const VALID_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 
 	const validateFile = (file) => {
 		if (!VALID_TYPES.includes(file.type)) {
@@ -43,8 +43,8 @@ export function ImageUpload({
 		const newErrors = [];
 
 		// Check total count limit
-		if (images.length + fileArray.length > MAX_IMAGES) {
-			newErrors.push(`Maximum ${MAX_IMAGES} images allowed`);
+                if (images.length + fileArray.length > maxImages) {
+                        newErrors.push(`Maximum ${maxImages} images allowed`);
 			setErrors(newErrors);
 			return;
 		}
@@ -141,8 +141,8 @@ export function ImageUpload({
 				<Label className="text-sm font-medium">
 					{label} {required && <span className="text-red-500">*</span>}
 				</Label>
-				<p className="text-xs text-gray-500 mt-1">
-					Upload up to {MAX_IMAGES} images. At least 1 image is required.
+                                <p className="text-xs text-gray-500 mt-1">
+                                        Upload up to {maxImages} images. At least 1 image is required.
 					Supported formats: JPEG, PNG, WebP (Max 5MB each)
 				</p>
 			</div>
@@ -233,8 +233,8 @@ export function ImageUpload({
 						hasValidationError ? "text-red-500" : "text-gray-500"
 					}`}
 				>
-					{images.length} / {MAX_IMAGES} images
-				</span>
+                                        {images.length} / {maxImages} images
+                                </span>
 			</div>
 		</div>
 	);

--- a/components/AdminPanel/Popups/AddProductPopup.jsx
+++ b/components/AdminPanel/Popups/AddProductPopup.jsx
@@ -218,7 +218,7 @@ export function AddProductPopup({ open, onOpenChange }) {
 									onImagesChange={(images) =>
 										setFormData({ ...formData, images })
 									}
-									maxImages={5}
+                                                                    maxImages={10}
 									label="Product Images"
 									required={true}
 								/>

--- a/components/AdminPanel/Popups/BulkUpdateProductsPopuup.jsx
+++ b/components/AdminPanel/Popups/BulkUpdateProductsPopuup.jsx
@@ -383,7 +383,7 @@ export function BulkUpdateProductsPopup({
 									onImagesChange={(images) =>
 										setFormData({ ...formData, images })
 									}
-									maxImages={5}
+                                                                    maxImages={10}
 									label="New Product Images"
 									required={false}
 								/>

--- a/components/AdminPanel/Popups/UpdateProductPopup.jsx
+++ b/components/AdminPanel/Popups/UpdateProductPopup.jsx
@@ -288,7 +288,7 @@ export function UpdateProductPopup({ open, onOpenChange, product }) {
                                                                         onImagesChange={(images) =>
                                                                                 setFormData({ ...formData, images })
                                                                         }
-                                                                        maxImages={5}
+                                                                        maxImages={10}
                                                                         label="Product Images"
                                                                         required={false}
                                                                 />


### PR DESCRIPTION
## Summary
- Allow ImageUpload component to accept configurable `maxImages` and default to 5.
- Raise admin add/update product image limit from 5 to 10 across forms.
