### PR TITLE
Fix admin auth persistence after refresh

### DIFF
--- a/store/adminAuthStore.js
+++ b/store/adminAuthStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
+import { useState, useEffect } from "react";
 
 export const useAdminAuthStore = create(
 	devtools(
@@ -30,4 +31,19 @@ export const useUserEmail = () =>
 export const useUserProfilePic = () =>
 	useAdminAuthStore((state) => state.user?.profilePic || "");
 
-export const useIsAuthenticated = () => useAdminAuthStore((state) => !!state.user);
+export const useIsAuthenticated = () => {
+        const isAuthenticated = useAdminAuthStore((state) => !!state.user);
+        const [hasHydrated, setHasHydrated] = useState(false);
+
+        useEffect(() => {
+                const unsub = useAdminAuthStore.persist.onFinishHydration(() =>
+                        setHasHydrated(true)
+                );
+                if (useAdminAuthStore.persist.hasHydrated()) {
+                        setHasHydrated(true);
+                }
+                return () => unsub();
+        }, []);
+
+        return hasHydrated ? isAuthenticated : true;
+};


### PR DESCRIPTION
## Summary
- handle persistence hydration in admin auth store
- prevent redirect to login during initial store hydration
