### PR TITLE
Add policy pages and link in footers

### DIFF
--- a/app/cancellation-refund-policy/page.jsx
+++ b/app/cancellation-refund-policy/page.jsx
@@ -1,0 +1,24 @@
+export const metadata = {
+  title: "Cancellation & Refund Policy | LADWA Partners",
+  description: "Guidelines on order cancellations and refunds for purchases made on LADWA Partners."
+};
+
+export default function CancellationRefundPage() {
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Cancellation & Refund Policy</h1>
+      <p>
+        Orders can be cancelled within 24 hours of placement, provided they have
+        not yet been dispatched. To request a cancellation, contact our support
+        team with your order details.
+      </p>
+      <p>
+        Refunds are processed to the original payment method within 7 working
+        days after the returned items are received and inspected. Shipping
+        charges are non-refundable unless the return is due to a defect or error
+        on our part.
+      </p>
+    </main>
+  );
+}
+

--- a/app/pricing-policy/page.jsx
+++ b/app/pricing-policy/page.jsx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Pricing Policy | LADWA Partners",
+  description: "Learn how LADWA Partners sets and updates product prices on our platform."
+};
+
+export default function PricingPolicyPage() {
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Pricing Policy</h1>
+      <p>
+        Prices for all products listed on LADWA Partners are displayed in Indian
+        Rupees (INR) and include applicable taxes unless stated otherwise. We
+        make every effort to provide accurate pricing, but prices may change
+        without prior notice due to market fluctuations or supplier updates.
+      </p>
+      <p>
+        Promotional prices and discounts are valid only for the duration of the
+        offer and cannot be combined with other promotions unless explicitly
+        mentioned. In the event of a pricing error, we reserve the right to
+        cancel orders placed at the incorrect price and will notify affected
+        customers promptly.
+      </p>
+    </main>
+  );
+}
+

--- a/app/privacy-policy/page.jsx
+++ b/app/privacy-policy/page.jsx
@@ -1,0 +1,24 @@
+export const metadata = {
+  title: "Privacy Policy | LADWA Partners",
+  description: "Details on how LADWA Partners collects, uses, and protects your personal information."
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p>
+        We value your privacy and are committed to protecting your personal
+        information. Data collected through our platform is used to process
+        orders, improve services, and communicate important updates. We do not
+        sell or rent personal information to third parties.
+      </p>
+      <p>
+        Access to your data is restricted to authorized personnel only. You may
+        request to review or delete your data by contacting our support team.
+        Continued use of our services signifies your consent to this policy.
+      </p>
+    </main>
+  );
+}
+

--- a/app/shipping-policy/page.jsx
+++ b/app/shipping-policy/page.jsx
@@ -1,0 +1,24 @@
+export const metadata = {
+  title: "Shipping Policy | LADWA Partners",
+  description: "Information on shipping methods, timelines, and charges for orders placed on LADWA Partners."
+};
+
+export default function ShippingPolicyPage() {
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Shipping Policy</h1>
+      <p>
+        We ship orders across India using trusted logistics partners. Orders are
+        typically processed within 2 working days and delivered within 3-7
+        business days depending on the destination. Tracking information will be
+        provided once the order is dispatched.
+      </p>
+      <p>
+        Shipping charges are calculated at checkout based on order weight and
+        destination. Free shipping promotions, if available, will be clearly
+        indicated. Currently, we do not support international shipping.
+      </p>
+    </main>
+  );
+}
+

--- a/app/terms-and-conditions/page.jsx
+++ b/app/terms-and-conditions/page.jsx
@@ -1,0 +1,25 @@
+export const metadata = {
+  title: "Terms and Conditions | LADWA Partners",
+  description: "Understand the rules and guidelines for using the LADWA Partners website and services."
+};
+
+export default function TermsConditionsPage() {
+  return (
+    <main className="max-w-4xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Terms and Conditions</h1>
+      <p>
+        By accessing or using the LADWA Partners website, you agree to comply
+        with these terms and all applicable laws. Users are responsible for
+        maintaining the confidentiality of their account information and for all
+        activities that occur under their account.
+      </p>
+      <p>
+        We reserve the right to modify or discontinue services at any time
+        without prior notice. Any disputes arising from the use of our platform
+        will be governed by the laws of India and subject to the jurisdiction of
+        the courts in India.
+      </p>
+    </main>
+  );
+}
+

--- a/components/BuyerPanel/Footer.jsx
+++ b/components/BuyerPanel/Footer.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { Facebook, Instagram, Linkedin } from "lucide-react";
 import Logo from "@/public/ladwapartners.png";
 
@@ -14,11 +15,22 @@ export default function Footer() {
 			title: "Account",
 			items: ["My Account", "Login / Register", "Cart", "Wishlist", "Shop"],
 		},
-		quickLinks: {
-			title: "Quick Link",
-			items: ["Privacy Policy", "Terms Of Use", "FAQ", "Contact Us"],
-		},
-	};
+                quickLinks: {
+                        title: "Quick Link",
+                        items: [
+                                { label: "Pricing Policy", href: "/pricing-policy" },
+                                { label: "Shipping Policy", href: "/shipping-policy" },
+                                { label: "Terms & Conditions", href: "/terms-and-conditions" },
+                                { label: "Privacy Policy", href: "/privacy-policy" },
+                                {
+                                        label: "Cancellation & Refund",
+                                        href: "/cancellation-refund-policy",
+                                },
+                                { label: "FAQ", href: "/faq" },
+                                { label: "Contact Us", href: "/contact" },
+                        ],
+                },
+        };
 
 	return (
 		<footer className="bg-black text-white py-8 md:py-16">
@@ -85,12 +97,13 @@ export default function Footer() {
                                                </h3>
                                                <div className="space-y-3 text-gray-400">
                                                        {footerSections.quickLinks.items.map((item, index) => (
-                                                               <p
+                                                               <Link
                                                                        key={index}
-                                                                       className="hover:text-white cursor-pointer transition-colors"
+                                                                       href={item.href}
+                                                                       className="hover:text-white cursor-pointer transition-colors block"
                                                                >
-                                                                       {item}
-                                                               </p>
+                                                                       {item.label}
+                                                               </Link>
                                                        ))}
                                                </div>
                                        </div>

--- a/components/SellerPanel/Footer.jsx
+++ b/components/SellerPanel/Footer.jsx
@@ -22,16 +22,22 @@ export default function Footer() {
 				{ label: "Shop", href: "/shop" },
 			],
 		},
-		quickLinks: {
-			title: "Quick Link",
-			links: [
-				{ label: "Privacy Policy", href: "/privacy" },
-				{ label: "Terms Of Use", href: "/terms" },
-				{ label: "FAQ", href: "/faq" },
-				{ label: "Contact", href: "/contact" },
-			],
-		},
-	};
+                quickLinks: {
+                        title: "Quick Link",
+                        links: [
+                                { label: "Pricing Policy", href: "/pricing-policy" },
+                                { label: "Shipping Policy", href: "/shipping-policy" },
+                                { label: "Terms and Conditions", href: "/terms-and-conditions" },
+                                { label: "Privacy Policy", href: "/privacy-policy" },
+                                {
+                                        label: "Cancellation & Refund",
+                                        href: "/cancellation-refund-policy",
+                                },
+                                { label: "FAQ", href: "/faq" },
+                                { label: "Contact", href: "/contact" },
+                        ],
+                },
+        };
 
 	return (
 		<footer className="bg-[#211F1D] text-white">


### PR DESCRIPTION
## Summary
- add dedicated pages for pricing, shipping, terms, privacy, and cancellation/refund policies
- link new policy pages within buyer and seller footers
