### PR TITLE
Use built-in font for invoice PDFs

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -6,14 +6,8 @@ import {
         Image,
         StyleSheet,
         pdf,
-        Font,
 } from "@react-pdf/renderer";
 import { companyInfo } from "@/constants/companyInfo.js";
-
-Font.register({
-        family: "NotoSans",
-        src: "https://fonts.gstatic.com/s/notosans/v27/o-0IIpQlx3QUlC5A4PNr4w.ttf",
-});
 
 const formatCurrency = (value) =>
         `₹${value.toLocaleString("en-IN", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -24,7 +18,7 @@ const styles = StyleSheet.create({
                 backgroundColor: "#FFFFFF",
                 padding: 30,
                 fontSize: 12,
-                fontFamily: "NotoSans",
+                fontFamily: "Helvetica",
                 lineHeight: 1.5,
         },
 	header: {


### PR DESCRIPTION
## Summary
- remove remote NotoSans font registration
- default invoice PDF to built-in Helvetica font

