### PR TITLE
Ensure rupee symbol renders in invoice PDFs

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -6,8 +6,24 @@ import {
         Image,
         StyleSheet,
         pdf,
+        Font,
 } from "@react-pdf/renderer";
 import { companyInfo } from "@/constants/companyInfo.js";
+
+// Register a font with the Indian Rupee symbol (₹) using a CDN source.
+Font.register({
+        family: "Roboto",
+        fonts: [
+                {
+                        src: "https://raw.githubusercontent.com/google/fonts/main/apache/roboto/Roboto-Regular.ttf",
+                        fontWeight: "normal",
+                },
+                {
+                        src: "https://raw.githubusercontent.com/google/fonts/main/apache/roboto/Roboto-Bold.ttf",
+                        fontWeight: "bold",
+                },
+        ],
+});
 
 const formatCurrency = (value) =>
         `₹${value.toLocaleString("en-IN", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -18,7 +34,7 @@ const styles = StyleSheet.create({
                 backgroundColor: "#FFFFFF",
                 padding: 30,
                 fontSize: 12,
-                fontFamily: "Helvetica",
+                fontFamily: "Roboto",
                 lineHeight: 1.5,
         },
 	header: {


### PR DESCRIPTION
## Summary
- Register CDN-hosted Roboto font so invoice PDFs include the Indian Rupee symbol without bundling binaries
- Remove bundled DejaVu font files from `public/fonts`
