### PR TITLE
Ensure rupee symbol renders in invoice PDFs

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -6,8 +6,25 @@ import {
         Image,
         StyleSheet,
         pdf,
+        Font,
 } from "@react-pdf/renderer";
 import { companyInfo } from "@/constants/companyInfo.js";
+
+// Register a font with the Indian Rupee symbol (₹) using a CDN that
+// supports query strings so React PDF can request only the glyphs it needs.
+Font.register({
+        family: "Roboto",
+        fonts: [
+                {
+                        src: "https://cdn.jsdelivr.net/npm/@fontsource/roboto/files/roboto-all-400-normal.woff",
+                        fontWeight: "normal",
+                },
+                {
+                        src: "https://cdn.jsdelivr.net/npm/@fontsource/roboto/files/roboto-all-700-normal.woff",
+                        fontWeight: "bold",
+                },
+        ],
+});
 
 const formatCurrency = (value) =>
         `₹${value.toLocaleString("en-IN", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -18,7 +35,7 @@ const styles = StyleSheet.create({
                 backgroundColor: "#FFFFFF",
                 padding: 30,
                 fontSize: 12,
-                fontFamily: "Helvetica",
+                fontFamily: "Roboto",
                 lineHeight: 1.5,
         },
 	header: {


### PR DESCRIPTION
## Summary
- Load Roboto from jsDelivr so React PDF can fetch glyph subsets and display the ₹ symbol
- Keep invoice styles using the registered Roboto font

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68b57a6c4f00832e9ca16c2be24b4131