### PR TITLE
feat: add ship-to address selection and invoice display

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -237,10 +237,10 @@ export default function CheckoutPage() {
                         return;
                 }
 
-		if (!getSelectedAddress()) {
-			toast.error("Please select a delivery address");
-			return;
-		}
+                if (!getSelectedAddress()) {
+                        toast.error("Please select a ship to address");
+                        return;
+                }
 
 		try {
 			const userId = user?._id || user?.id;
@@ -271,15 +271,15 @@ export default function CheckoutPage() {
 			<Card>
 				<CardHeader>
 					<CardTitle className="flex items-center gap-2">
-						<MapPin className="h-5 w-5" />
-						Delivery Address
+                                                <MapPin className="h-5 w-5" />
+                                                Ship To Address
 					</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
 					{/* Saved Addresses */}
-					{savedAddresses.length > 0 && (
-						<div className="space-y-3">
-							<h4 className="font-medium">Saved Addresses</h4>
+                                        {savedAddresses.length > 0 && (
+                                                <div className="space-y-3">
+                                                        <h4 className="font-medium">Saved Ship To Addresses</h4>
 							{savedAddresses.map((address) => (
 								<div
 									key={address._id}
@@ -333,16 +333,16 @@ export default function CheckoutPage() {
 					)}
 
 					{/* Add New Address Button */}
-					{!isAddingNewAddress && (
-						<Button
-							variant="outline"
-							onClick={toggleAddNewAddress}
-							className="w-full"
-						>
-							<Plus className="h-4 w-4 mr-2" />
-							Add New Address
-						</Button>
-					)}
+                                        {!isAddingNewAddress && (
+                                                <Button
+                                                        variant="outline"
+                                                        onClick={toggleAddNewAddress}
+                                                        className="w-full"
+                                                >
+                                                        <Plus className="h-4 w-4 mr-2" />
+                                                        Add Ship To Address
+                                                </Button>
+                                        )}
 
 					{/* New Address Form */}
 					{isAddingNewAddress && (
@@ -640,18 +640,32 @@ export default function CheckoutPage() {
 	);
 
 	// Order Summary Component
-	const OrderSummary = useMemo(() => {
-		const currentCoupon =
-			checkoutType === "cart" ? cartAppliedCoupon : appliedCoupon;
+        const OrderSummary = useMemo(() => {
+                const currentCoupon =
+                        checkoutType === "cart" ? cartAppliedCoupon : appliedCoupon;
+                const selectedAddress = getSelectedAddress();
 
-		return (
-			<Card className="sticky top-4">
-				<CardHeader>
-					<CardTitle>Order Summary</CardTitle>
-				</CardHeader>
-				<CardContent className="space-y-4">
-					{/* Items */}
-					<div className="space-y-3">
+                return (
+                        <Card className="sticky top-4">
+                                <CardHeader>
+                                        <CardTitle>Order Summary</CardTitle>
+                                </CardHeader>
+                                <CardContent className="space-y-4">
+                                        {selectedAddress && (
+                                                <>
+                                                        <div className="text-sm">
+                                                                <p className="font-medium">Ship To</p>
+                                                                <p>{selectedAddress.name}</p>
+                                                                <p className="text-gray-600">
+                                                                        {selectedAddress.street}, {selectedAddress.city}, {selectedAddress.state} - {selectedAddress.zipCode}
+                                                                </p>
+                                                        </div>
+                                                        <Separator />
+                                                </>
+                                        )}
+
+                                        {/* Items */}
+                                        <div className="space-y-3">
 						{orderSummary.items.map((item, index) => (
 							<div key={index} className="flex items-center gap-3">
 								<div className="relative w-12 h-12 bg-gray-100 rounded-lg overflow-hidden">
@@ -787,16 +801,18 @@ export default function CheckoutPage() {
 				</CardContent>
 			</Card>
 		);
-	}, [
-		orderSummary,
-		appliedCoupon,
-		cartAppliedCoupon,
-		checkoutType,
-		couponCode,
-		handleApplyCoupon,
-		removeCoupon,
-		isLoading,
-	]);
+        }, [
+                orderSummary,
+                appliedCoupon,
+                cartAppliedCoupon,
+                checkoutType,
+                couponCode,
+                handleApplyCoupon,
+                removeCoupon,
+                isLoading,
+                getSelectedAddress,
+                selectedAddressId,
+        ]);
 
 	return (
 		<>

--- a/components/BuyerPanel/account/tabs/MyProfile.jsx
+++ b/components/BuyerPanel/account/tabs/MyProfile.jsx
@@ -384,14 +384,14 @@ export function MyProfile() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
             <div>
-              <CardTitle>Addresses</CardTitle>
+              <CardTitle>Ship To Addresses</CardTitle>
               <CardDescription>
-                Manage your shipping and billing addresses
+                Manage your ship-to addresses
               </CardDescription>
             </div>
             <Button size="sm" onClick={openNewAddress}>
               <Plus className="h-4 w-4 mr-2" />
-              Add Address
+              Add Ship To Address
             </Button>
           </CardHeader>
           <CardContent>

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -157,17 +157,31 @@ const InvoiceDocument = ({ order }) => {
 
 			{/* Customer Information */}
 			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Bill To:</Text>
-				<Text>{order.customerName}</Text>
-				<Text>{order.customerEmail}</Text>
-				<Text>{order.customerMobile}</Text>
-				{order.deliveryAddress && (
-					<Text>{order.deliveryAddress.fullAddress}</Text>
-				)}
-			</View>
+                                <View style={styles.row}>
+                                        <View>
+                                                <Text style={styles.sectionTitle}>Bill To:</Text>
+                                                <Text>{order.customerName}</Text>
+                                                <Text>{order.customerEmail}</Text>
+                                                <Text>{order.customerMobile}</Text>
+                                        </View>
+                                        {order.deliveryAddress && (
+                                                <View>
+                                                        <Text style={styles.sectionTitle}>Ship To:</Text>
+                                                        {order.deliveryAddress.name && (
+                                                                <Text>{order.deliveryAddress.name}</Text>
+                                                        )}
+                                                        <Text>{order.deliveryAddress.street}</Text>
+                                                        <Text>
+                                                                {order.deliveryAddress.city}, {order.deliveryAddress.state} - {order.deliveryAddress.zipCode}
+                                                        </Text>
+                                                        <Text>{order.deliveryAddress.country}</Text>
+                                                </View>
+                                        )}
+                                </View>
+                        </View>
 
-			{/* Order Details */}
-			<View style={styles.section}>
+                        {/* Order Details */}
+                        <View style={styles.section}>
 				<Text style={styles.sectionTitle}>Order Details:</Text>
 				<View style={styles.row}>
 					<Text>

--- a/store/checkoutStore.js
+++ b/store/checkoutStore.js
@@ -455,10 +455,10 @@ export const useCheckoutStore = create(
 
 					const selectedAddress = get().getSelectedAddress();
 
-					if (!selectedAddress) {
-						toast.error("Please select a delivery address");
-						return { success: false, error: "No delivery address selected" };
-					}
+                                        if (!selectedAddress) {
+                                                toast.error("Please select a ship to address");
+                                                return { success: false, error: "No ship to address selected" };
+                                        }
 
 					if (orderSummary.items.length === 0) {
 						toast.error("No items to checkout");
@@ -677,9 +677,9 @@ export const useCheckoutStore = create(
 					if (!customerInfo.mobile.trim())
 						errors.push("Mobile number is required");
 
-					// Validate delivery address
-					if (!selectedAddressId)
-						errors.push("Please select a delivery address");
+                                        // Validate ship to address
+                                        if (!selectedAddressId)
+                                                errors.push("Please select a ship to address");
 
 					// Validate order items
 					if (orderSummary.items.length === 0) errors.push("No items in order");


### PR DESCRIPTION
## Summary
- rename profile addresses section to "Ship To" and allow managing ship-to addresses
- require and display ship-to address during checkout and in order summary
- show ship-to block beside bill-to on generated invoices

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot serialize key "parse" in parser: Function values are not supported.)

------
https://chatgpt.com/codex/tasks/task_e_68b57b67eb08832eafa90ae4c62f8eed