### PR TITLE
feat: send order emails with cc and bcc

### DIFF
--- a/app/api/admin/orders/[id]/route.js
+++ b/app/api/admin/orders/[id]/route.js
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/lib/dbConnect.js";
 import Order from "@/model/Order.js";
+import { sendMail } from "@/lib/mail";
 
 export async function GET(request, { params }) {
 	try {
 		await dbConnect();
 
-		const order = await Order.findById(params.id)
-			.populate("userId", "firstName lastName email mobile")
-			.populate("products.productId", "name images price")
-			.populate("couponApplied.couponId", "code discountType discountValue");
+                const order = await Order.findById(params.id)
+                        .populate("userId", "firstName lastName email mobile")
+                        .populate("products.productId", "name images price")
+                        .populate("couponApplied.couponId", "code discountType discountValue");
 
 		if (!order) {
 			return NextResponse.json(
@@ -37,12 +38,12 @@ export async function PUT(request, { params }) {
 
 		const updateData = await request.json();
 
-		const order = await Order.findByIdAndUpdate(params.id, updateData, {
-			new: true,
-			runValidators: true,
-		})
-			.populate("userId", "firstName lastName email")
-			.populate("products.productId", "name images");
+                const order = await Order.findByIdAndUpdate(params.id, updateData, {
+                        new: true,
+                        runValidators: true,
+                })
+                        .populate("userId", "firstName lastName email")
+                        .populate("products.productId", "name images");
 
 		if (!order) {
 			return NextResponse.json(
@@ -51,11 +52,31 @@ export async function PUT(request, { params }) {
 			);
 		}
 
-		return NextResponse.json({
-			success: true,
-			message: "Order updated successfully",
-			order,
-		});
+                if (updateData.status && order.userId?.email) {
+                        const html = `
+                                <div style="font-family:Arial,sans-serif;font-size:16px;color:#333;">
+                                        <h2 style="color:#4f46e5;">Order Status Updated</h2>
+                                        <p>Hi ${order.userId.firstName},</p>
+                                        <p>Your order <strong>${order.orderNumber}</strong> status has been updated to <strong>${order.status.toUpperCase()}</strong>.</p>
+                                        <p style="margin-top:20px;">Best regards,<br/>Ladwa Partners</p>
+                                </div>
+                        `;
+                        try {
+                                await sendMail({
+                                        to: order.userId.email,
+                                        subject: `Order ${order.orderNumber} - ${order.status}`,
+                                        html,
+                                });
+                        } catch (mailErr) {
+                                console.error("Order status email error:", mailErr);
+                        }
+                }
+
+                return NextResponse.json({
+                        success: true,
+                        message: "Order updated successfully",
+                        order,
+                });
 	} catch (error) {
 		console.error("Error updating order:", error);
 		return NextResponse.json(

--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -4,7 +4,7 @@ import Product from "@/model/Product";
 import Cart from "@/model/Cart";
 import User from "@/model/User";
 import { dbConnect } from "@/lib/dbConnect.js";
-import nodemailer from "nodemailer";
+import { sendMail } from "@/lib/mail";
 
 export async function POST(req) {
 	try {
@@ -49,14 +49,6 @@ export async function POST(req) {
                                 prefs?.channels?.email &&
                                 prefs?.settings?.["order-placed"]?.email
                         ) {
-                                const transporter = nodemailer.createTransport({
-                                        service: "gmail",
-                                        auth: {
-                                                user: process.env.MAIL_USER,
-                                                pass: process.env.MAIL_PASS,
-                                        },
-                                });
-
                                 const html = `
                                         <div style="font-family:Arial,sans-serif;font-size:16px;color:#333;">
                                                 <h2 style="color:#4f46e5;">Thank you for your order!</h2>
@@ -67,9 +59,7 @@ export async function POST(req) {
                                                 <p style="margin-top:20px;">Best regards,<br/>Ladwa Partners</p>
                                         </div>
                                 `;
-
-                                await transporter.sendMail({
-                                        from: process.env.MAIL_USER,
+                                await sendMail({
                                         to: user.email,
                                         subject: `Order Confirmed - ${order.orderNumber}`,
                                         html,

--- a/constants/companyInfo.js
+++ b/constants/companyInfo.js
@@ -3,6 +3,8 @@ export const companyInfo = {
     logo: "/ladwapartners.png",
     website: "https://ladwapartners.com",
     email: "contact@ladwapartners.com",
+    ccEmails: [],
+    bccEmails: [],
     phone: "+91 8971815400",
     address: [
         "Beside St. Anne's Church, Mestrhi Palya, Rachenahalli",

--- a/lib/mail.js
+++ b/lib/mail.js
@@ -1,0 +1,24 @@
+import nodemailer from "nodemailer";
+import { companyInfo } from "@/constants/companyInfo";
+
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  auth: {
+    user: process.env.MAIL_USER,
+    pass: process.env.MAIL_PASS,
+  },
+});
+
+export async function sendMail({ to, subject, html }) {
+  const cc = companyInfo.ccEmails && companyInfo.ccEmails.length ? companyInfo.ccEmails : undefined;
+  const bcc = companyInfo.bccEmails && companyInfo.bccEmails.length ? companyInfo.bccEmails : undefined;
+
+  return transporter.sendMail({
+    from: process.env.MAIL_USER,
+    to,
+    cc,
+    bcc,
+    subject,
+    html,
+  });
+}


### PR DESCRIPTION
## Summary
- include cc/bcc placeholders in company info
- send order placed and status update emails to cc/bcc recipients
- centralize mail transport logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59830cd58832e9ef7b4cb16c89271