### PR TITLE
feat: add sweetalert api wrapper

### DIFF
--- a/components/BuyerPanel/account/tabs/NotificationSettings.jsx
+++ b/components/BuyerPanel/account/tabs/NotificationSettings.jsx
@@ -21,7 +21,7 @@ import {
   ShoppingCart,
   CreditCard,
 } from "lucide-react";
-import { toast } from "react-hot-toast";
+import { apiRequest } from "@/lib/api";
 
 const cardVariants = {
   hidden: { opacity: 0, y: 20 },
@@ -78,15 +78,17 @@ export function NotificationSettings() {
   useEffect(() => {
     const fetchPreferences = async () => {
       try {
-        const res = await fetch("/api/user/notifications");
-        if (res.ok) {
-          const data = await res.json();
-          if (data.preferences) {
-            setPreferences((prev) => ({ ...prev, ...data.preferences }));
+        const data = await apiRequest(
+          "/api/user/notifications",
+          {},
+          {
+            successMessage: null,
+            errorMessage: "Unable to load notification settings.",
           }
+        );
+        if (data.preferences) {
+          setPreferences((prev) => ({ ...prev, ...data.preferences }));
         }
-      } catch (error) {
-        console.error(error);
       } finally {
         setLoading(false);
       }
@@ -120,16 +122,20 @@ export function NotificationSettings() {
 
   const handleSave = async () => {
     try {
-      const res = await fetch("/api/user/notifications", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ preferences }),
-      });
-      const data = await res.json();
-      if (!res.ok || !data.success) throw new Error();
-      toast.success("Notification settings saved");
+      await apiRequest(
+        "/api/user/notifications",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ preferences }),
+        },
+        {
+          successMessage: "Notification settings saved.",
+          errorMessage: "Failed to save settings. Please try again.",
+        }
+      );
     } catch (error) {
-      toast.error("Failed to save settings");
+      // apiRequest handles the alert
     }
   };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,47 @@
+import Swal from "sweetalert2";
+
+/**
+ * Wrapper around fetch that shows SweetAlert messages on success or failure.
+ * @param {string} url - API endpoint to call.
+ * @param {RequestInit} [options] - fetch options.
+ * @param {Object} [messages] - Optional success or error messages.
+ * @param {string|null} [messages.successMessage] - Message for successful requests. Pass null to suppress.
+ * @param {string} [messages.errorMessage] - Message when the request fails.
+ */
+export async function apiRequest(
+  url,
+  options = {},
+  { successMessage, errorMessage } = {}
+) {
+  const successText =
+    successMessage === undefined
+      ? "Request completed successfully."
+      : successMessage;
+  const errorText =
+    errorMessage ?? "Something went wrong. Please try again.";
+
+  try {
+    const res = await fetch(url, options);
+    const data = await res.json().catch(() => ({}));
+
+    if (!res.ok || data?.success === false) {
+      const message = data?.message || errorText;
+      Swal.fire({ icon: "error", title: "Error", text: message });
+      throw new Error(message);
+    }
+
+    if (successText) {
+      Swal.fire({
+        icon: "success",
+        title: "Success",
+        text: data?.message || successText,
+      });
+    }
+
+    return data;
+  } catch (err) {
+    const message = err.message || errorText;
+    Swal.fire({ icon: "error", title: "Error", text: message });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `apiRequest` helper that displays SweetAlert messages on API success or failure
- use `apiRequest` in notification settings to alert users when settings load or save
