### PR TITLE
refactor: specify GST types

### DIFF
--- a/app/(buyers)/checkout/page.jsx
+++ b/app/(buyers)/checkout/page.jsx
@@ -769,19 +769,19 @@ export default function CheckoutPage() {
                                                         <div className="space-y-1">
                                                                 {orderSummary.gst.cgst > 0 && (
                                                                         <div className="flex justify-between">
-                                                                                <span>CGST (9%)</span>
+                                                                                <span>CGST 9%</span>
                                                                                 <span>₹{orderSummary.gst.cgst.toLocaleString()}</span>
                                                                         </div>
                                                                 )}
                                                                 {orderSummary.gst.sgst > 0 && (
                                                                         <div className="flex justify-between">
-                                                                                <span>SGST (9%)</span>
+                                                                                <span>SGST 9%</span>
                                                                                 <span>₹{orderSummary.gst.sgst.toLocaleString()}</span>
                                                                         </div>
                                                                 )}
                                                                 {orderSummary.gst.igst > 0 && (
                                                                         <div className="flex justify-between">
-                                                                                <span>IGST (18%)</span>
+                                                                                <span>IGST 18%</span>
                                                                                 <span>₹{orderSummary.gst.igst.toLocaleString()}</span>
                                                                         </div>
                                                                 )}

--- a/components/AdminPanel/Popups/InvoicePopup.jsx
+++ b/components/AdminPanel/Popups/InvoicePopup.jsx
@@ -222,25 +222,25 @@ export function InvoicePopup({ open, onOpenChange, order, downloadInvoice: downl
                                                 {order.tax > 0 && (
                                                         <div className="space-y-1">
                                                                 <div className="flex justify-between">
-                                                               <span>GST (18%)</span>
-                                                               <span>₹{order.tax.toFixed(2)}</span>
+                                                                        <span>Total Tax</span>
+                                                                        <span>₹{order.tax.toFixed(2)}</span>
                                                                 </div>
                                                                 {order.gst?.cgst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                               <span>CGST (9%)</span>
-                                                                               <span>₹{order.gst.cgst.toFixed(2)}</span>
+                                                                                <span>CGST 9%</span>
+                                                                                <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 {order.gst?.sgst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                               <span>SGST (9%)</span>
-                                                                               <span>₹{order.gst.sgst.toFixed(2)}</span>
+                                                                                <span>SGST 9%</span>
+                                                                                <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                                 {order.gst?.igst > 0 && (
                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                               <span>IGST (18%)</span>
-                                                                               <span>₹{order.gst.igst.toFixed(2)}</span>
+                                                                                <span>IGST 18%</span>
+                                                                                <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                         </div>
                                                                 )}
                                                         </div>

--- a/components/AdminPanel/Popups/OrderDetailsPopup.jsx
+++ b/components/AdminPanel/Popups/OrderDetailsPopup.jsx
@@ -272,24 +272,24 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                         {order.tax > 0 && (
                                                                                 <div className="space-y-1">
                                                                                         <div className="flex justify-between">
-                                                                                                <span>GST (18%)</span>
+                                                                                                <span>Total Tax</span>
                                                                                                 <span>₹{order.tax.toFixed(2)}</span>
                                                                                         </div>
                                                                                         {order.gst?.cgst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
-                                                                                                        <span>CGST (9%)</span>
+                                                                                                        <span>CGST 9%</span>
                                                                                                         <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}
                                                                                         {order.gst?.sgst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
-                                                                                                        <span>SGST (9%)</span>
+                                                                                                        <span>SGST 9%</span>
                                                                                                         <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}
                                                                                         {order.gst?.igst > 0 && (
                                                                                                 <div className="flex justify-between text-xs pl-2">
-                                                                                                        <span>IGST (18%)</span>
+                                                                                                        <span>IGST 18%</span>
                                                                                                         <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                                                 </div>
                                                                                         )}

--- a/components/BuyerPanel/account/OrderDetailsPopup.jsx
+++ b/components/BuyerPanel/account/OrderDetailsPopup.jsx
@@ -214,24 +214,24 @@ export function OrderDetailsPopup({ open, onOpenChange, order }) {
                                                                 {order.tax > 0 && (
                                                                         <div className="space-y-1">
                                                                                 <div className="flex justify-between">
-                                                                                        <span>GST (18%)</span>
+                                                                                        <span>Total Tax</span>
                                                                                         <span>₹{order.tax.toFixed(2)}</span>
                                                                                 </div>
                                                                                 {order.gst?.cgst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                                <span>CGST (9%)</span>
+                                                                                                <span>CGST 9%</span>
                                                                                                 <span>₹{order.gst.cgst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}
                                                                                 {order.gst?.sgst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                                <span>SGST (9%)</span>
+                                                                                                <span>SGST 9%</span>
                                                                                                 <span>₹{order.gst.sgst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}
                                                                                 {order.gst?.igst > 0 && (
                                                                                         <div className="flex justify-between text-xs pl-2">
-                                                                                                <span>IGST (18%)</span>
+                                                                                                <span>IGST 18%</span>
                                                                                                 <span>₹{order.gst.igst.toFixed(2)}</span>
                                                                                         </div>
                                                                                 )}

--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -258,10 +258,10 @@ const InvoiceDocument = ({ order }) => {
                                {order.products.map((product, index) => {
                                        const taxType =
                                                order.gst?.igst > 0
-                                                       ? "IGST (18%)"
+                                                       ? "IGST 18%"
                                                        : order.gst?.cgst > 0 || order.gst?.sgst > 0
-                                                       ? "CGST/SGST (9% each)"
-                                                       : "GST";
+                                                       ? "CGST 9%\nSGST 9%"
+                                                       : "";
                                        const productTax =
                                                order.tax > 0 && order.subtotal > 0
                                                        ? (product.totalPrice / order.subtotal) * order.tax


### PR DESCRIPTION
## Summary
- remove generic GST labels in checkout and order summaries
- list IGST, CGST, SGST separately in invoice PDF and popups
