### PR TITLE
fix: respect GST verification status

### DIFF
--- a/store/authStore.js
+++ b/store/authStore.js
@@ -32,4 +32,9 @@ export const useUserProfilePic = () =>
 
 export const useIsAuthenticated = () => useAuthStore((state) => !!state.user);
 
-export const useIsGstVerified = () => useAuthStore((state)=> !!state.user?.gstVerified)
+export const useIsGstVerified = () =>
+        useAuthStore(
+                (state) =>
+                        state.user?.gstVerified === true ||
+                        state.user?.gstVerificationStatus === "APPROVED"
+        );


### PR DESCRIPTION
## Summary
- ensure GST verification check uses `gstVerified` or the verification status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot serialize key "parse" in parser: Function values are not supported.)*

------
https://chatgpt.com/codex/tasks/task_e_68b69641fcfc832ebadcb5d282bd042e