### PR TITLE
Show GST breakdown in invoice PDF

### DIFF
--- a/lib/generateInvoicePDF.js
+++ b/lib/generateInvoicePDF.js
@@ -152,6 +152,13 @@ const InvoiceDocument = ({ order }) => {
                         ? `${companyInfo.website}${companyInfo.logo}`
                         : companyInfo.logo;
 
+        const cgstRate =
+                order.subtotal ? (order.gst?.cgst / order.subtotal) * 100 : 0;
+        const sgstRate =
+                order.subtotal ? (order.gst?.sgst / order.subtotal) * 100 : 0;
+        const igstRate =
+                order.subtotal ? (order.gst?.igst / order.subtotal) * 100 : 0;
+
         return (
                 <Document>
                         <Page size="A4" style={styles.page}>
@@ -297,15 +304,48 @@ const InvoiceDocument = ({ order }) => {
 
                        {/* Totals */}
                        <View style={styles.totalSection}>
-                                <View style={styles.totalRow}>
-                                        <Text>Subtotal:</Text>
-                                        <Text style={styles.alignRight}>{formatCurrency(order.subtotal)}</Text>
-                                </View>
-                                {order.shippingCost > 0 && (
-                                        <View style={styles.totalRow}>
-                                                <Text>Shipping:</Text>
-                                                <Text style={styles.alignRight}>{formatCurrency(order.shippingCost)}</Text>
-                                        </View>
+                               <View style={styles.totalRow}>
+                                       <Text>Subtotal:</Text>
+                                       <Text style={styles.alignRight}>{formatCurrency(order.subtotal)}</Text>
+                               </View>
+                               {order.gst?.igst > 0 ? (
+                                       <View style={styles.totalRow}>
+                                               <Text>
+                                                       IGST {igstRate.toFixed(0)}%:
+                                               </Text>
+                                               <Text style={styles.alignRight}>
+                                                       {formatCurrency(order.gst.igst)}
+                                               </Text>
+                                       </View>
+                               ) : (
+                                       <>
+                                               {order.gst?.cgst > 0 && (
+                                                       <View style={styles.totalRow}>
+                                                               <Text>
+                                                                       CGST {cgstRate.toFixed(0)}%:
+                                                               </Text>
+                                                               <Text style={styles.alignRight}>
+                                                                       {formatCurrency(order.gst.cgst)}
+                                                               </Text>
+                                                       </View>
+                                               )}
+                                               {order.gst?.sgst > 0 && (
+                                                       <View style={styles.totalRow}>
+                                                               <Text>
+                                                                       SGST {sgstRate.toFixed(0)}%:
+                                                               </Text>
+                                                               <Text style={styles.alignRight}>
+                                                                       {formatCurrency(order.gst.sgst)}
+                                                               </Text>
+                                                       </View>
+                                               )}
+                                       </>
+                               )}
+                               {order.shippingCost > 0 && (
+                                       <View style={styles.totalRow}>
+                                               <Text>Shipping:</Text>
+                                               <Text style={styles.alignRight}>{formatCurrency(order.shippingCost)}</Text>
+                                       </View>
                                 )}
                                 {order.discount > 0 && (
                                         <View style={styles.totalRow}>


### PR DESCRIPTION
## Summary
- compute GST rates based on order subtotal for CGST, SGST, and IGST
- render GST amounts after subtotal in invoice PDF, splitting CGST and SGST when applicable
