### PR TITLE
chore: remove notification settings sidebar link

### DIFF
--- a/app/(buyers)/account/layout.js
+++ b/app/(buyers)/account/layout.js
@@ -26,7 +26,6 @@ export default function AccountLayout({ children }) {
 				"/account": "my-profile",
 				"/account/profile": "my-profile",
 				"/account/orders": "order-history",
-				"/account/notifications": "notification-settings",
 				"/account/help": "help-center",
 			};
 

--- a/components/BuyerPanel/BuyersLayoutClient.jsx
+++ b/components/BuyerPanel/BuyersLayoutClient.jsx
@@ -13,7 +13,6 @@ export default function BuyersLayoutClient({ children, categories }) {
 	const hideNavbar = [
 		"/account/profile",
 		"/account/orders",
-		"/account/notifications",
 		"/account/help",
 	].includes(pathname);
 	const [isMenuOpen, setIsMenuOpen] = useState(true);

--- a/components/BuyerPanel/account/AccountContent.jsx
+++ b/components/BuyerPanel/account/AccountContent.jsx
@@ -3,7 +3,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { OrderHistory } from "@/components/account/tabs/OrderHistory.jsx";
 import { MyProfile } from "@/components/account/tabs/MyProfile.jsx";
-import { NotificationSettings } from "@/components/account/tabs/NotificationSettings.jsx";
 import { HelpCenter } from "@/components/account/tabs/HelpCenter.jsx";
 
 const contentVariants = {
@@ -16,7 +15,6 @@ const contentVariants = {
 const tabComponents = {
 	"order-history": OrderHistory,
 	"my-profile": MyProfile,
-	"notification-settings": NotificationSettings,
 	"help-center": HelpCenter,
 };
 

--- a/components/BuyerPanel/account/AccountSidebar.jsx
+++ b/components/BuyerPanel/account/AccountSidebar.jsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { useRouter, usePathname } from "next/navigation";
-import { Package, User, Bell, HelpCircle, LogOut } from "lucide-react";
+import { Package, User, HelpCircle, LogOut } from "lucide-react";
 import { LogoutPopup } from "@/components/Shared/Popups/LogoutPopup.jsx";
 
 const sidebarItems = [
@@ -20,13 +20,6 @@ const sidebarItems = [
 		icon: Package,
 		description: "View your past orders",
 		href: "/account/orders",
-	},
-	{
-		id: "notification-settings",
-		title: "Notification Settings",
-		icon: Bell,
-		description: "Manage your notifications",
-		href: "/account/notifications",
 	},
 	{
 		id: "help-center",


### PR DESCRIPTION
## Summary
- hide Notification Settings from the account sidebar
- update account layout and buyer layout to remove references to the notifications tab
- clean up unused NotificationSettings tab mapping
