### PR TITLE
Fix subcategory filtering to match products

### DIFF
--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -47,8 +47,13 @@ export async function GET(request) {
                                 .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
                                 .join("[^a-zA-Z0-9]+");
 
+                        // Allow optional non-alphanumeric characters at the start and end so that
+                        // values with accidental leading/trailing spaces or punctuation still match.
                         query.subCategory = {
-                                $regex: new RegExp(`^${regexPattern}$`, "i"),
+                                $regex: new RegExp(
+                                        `^[^a-zA-Z0-9]*${regexPattern}[^a-zA-Z0-9]*$`,
+                                        "i"
+                                ),
                         };
                 }
 


### PR DESCRIPTION
## Summary
- handle accidental leading/trailing characters in subcategory filters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6aa6d2fd4832ebb4428947b854c23