### PR TITLE
Fix footer layout header props

### DIFF
--- a/app/(footer-pages)/layout.jsx
+++ b/app/(footer-pages)/layout.jsx
@@ -4,7 +4,7 @@ import Footer from "@/components/BuyerPanel/Footer";
 export default function FooterPagesLayout({ children }) {
   return (
     <div className="min-h-screen flex flex-col">
-      <Header isMenuOpen={false} showMenu={false} onMenuToggle={() => {}} />
+      <Header showMenu={false} />
       <main className="flex-grow">{children}</main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- avoid passing server-side handler to client Header component in footer pages layout to fix prerender error

## Testing
- `npm run lint` *(fails: Cannot serialize key "parse" in parser)*
- `npm run build` *(fails: Failed to fetch Google Fonts resources)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d283340832ea6db92ecf4137499